### PR TITLE
detect qmd deps in vignettes

### DIFF
--- a/R/utils-deps.R
+++ b/R/utils-deps.R
@@ -414,7 +414,7 @@ get_deps_in_vignettes <- function() {
   }
   
   x <- list.files(path = file.path(path, "vignettes"), 
-                  pattern = "\\.R$|\\.Rmd$", full.names = TRUE, 
+                  pattern = "\\.R$|\\.Rmd$|\\.qmd$", full.names = TRUE, 
                   ignore.case = TRUE, recursive = TRUE)
   
   if (!length(x)) {


### PR DESCRIPTION
I know qmd is not typically used in vignettes yet but I wanted it for a paper and won't be submitting to CRAN so it would be nice to have the dependencies tracked. 