### PR TITLE
Add download badges to README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -24,6 +24,8 @@ rcompendium <img src="man/figures/logo.png" align="right" style="float:right; he
 [![Website deployment](https://github.com/FRBCesab/rcompendium/actions/workflows/pkgdown.yaml/badge.svg)](https://github.com/FRBCesab/rcompendium/actions/workflows/pkgdown.yaml)
 [![codecov](https://codecov.io/gh/FRBCesab/rcompendium/branch/main/graph/badge.svg)](https://app.codecov.io/gh/FRBCesab/rcompendium)
 [![License: GPL (>= 2)](https://img.shields.io/badge/License-GPL%20%28%3E%3D%202%29-blue.svg)](https://choosealicense.com/licenses/gpl-2.0/)
+[![Total downloads](https://cranlogs.r-pkg.org/badges/grand-total/rcompendium?color=orange)](https://CRAN.R-project.org/package=rcompendium)
+[![Monthly downloads](https://cranlogs.r-pkg.org/badges/rcompendium)](https://CRAN.R-project.org/package=rcompendium)
 <!-- badges: end -->
 
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ deployment](https://github.com/FRBCesab/rcompendium/actions/workflows/pkgdown.ya
 [![codecov](https://codecov.io/gh/FRBCesab/rcompendium/branch/main/graph/badge.svg)](https://app.codecov.io/gh/FRBCesab/rcompendium)
 [![License: GPL (\>=
 2)](https://img.shields.io/badge/License-GPL%20%28%3E%3D%202%29-blue.svg)](https://choosealicense.com/licenses/gpl-2.0/)
+[![Total
+downloads](https://cranlogs.r-pkg.org/badges/grand-total/rcompendium?color=orange)](https://CRAN.R-project.org/package=rcompendium)
+[![Monthly
+downloads](https://cranlogs.r-pkg.org/badges/rcompendium)](https://CRAN.R-project.org/package=rcompendium)
 <!-- badges: end -->
 
 In the area of open science, making reproducible analyses is a strong


### PR DESCRIPTION
This PR include total and monthly download badges for the `rcompendium` package in the README to enhance visibility and provide users with insights into package usage.

[![Total
downloads](https://cranlogs.r-pkg.org/badges/grand-total/rcompendium?color=orange)](https://CRAN.R-project.org/package=rcompendium)
[![Monthly
downloads](https://cranlogs.r-pkg.org/badges/rcompendium)](https://CRAN.R-project.org/package=rcompendium)