### PR TITLE
Handle templates from GitHub

### DIFF
--- a/R/add_citation.R
+++ b/R/add_citation.R
@@ -88,18 +88,16 @@ add_citation <- function(
   pkg_version <- get_package_version()
   year <- format(Sys.Date(), "%Y")
 
-  ## Copy Template ----
+  ## Download template ----
 
   if (!dir.exists(file.path(path_proj(), "inst"))) {
     dir.create(file.path(path_proj(), "inst"), showWarnings = FALSE)
   }
 
-  invisible(
-    file.copy(
-      system.file(file.path("templates", "citation"), package = "rcompendium"),
-      path,
-      overwrite = TRUE
-    )
+  download_template(
+    slug = "package/CITATION",
+    filename = "CITATION",
+    outdir = file.path(path_proj(), "inst")
   )
 
   ## Change defaults values ----

--- a/R/add_code_of_conduct.R
+++ b/R/add_code_of_conduct.R
@@ -59,17 +59,12 @@ add_code_of_conduct <- function(
 
   stop_if_not_string(email)
 
-  ## Copy Template ----
+  ## Download template ----
 
-  invisible(
-    file.copy(
-      system.file(
-        file.path("templates", "CODE_OF_CONDUCT.md"),
-        package = "rcompendium"
-      ),
-      path,
-      overwrite = TRUE
-    )
+  download_template(
+    slug = "contributing/CODE_OF_CONDUCT.md",
+    filename = "CODE_OF_CONDUCT.md",
+    outdir = NULL
   )
 
   ## Change defaults values ----

--- a/R/add_contributing.R
+++ b/R/add_contributing.R
@@ -88,17 +88,12 @@ add_contributing <- function(
   project_name <- get_package_name()
   branch <- get_git_branch_name()
 
-  ## Copy Template ----
+  ## Download template ----
 
-  invisible(
-    file.copy(
-      system.file(
-        file.path("templates", "CONTRIBUTING.md"),
-        package = "rcompendium"
-      ),
-      path,
-      overwrite = TRUE
-    )
+  download_template(
+    slug = "contributing/CONTRIBUTING.md",
+    filename = "CONTRIBUTING.md",
+    outdir = NULL
   )
 
   ## Change defaults values ----
@@ -149,15 +144,10 @@ add_contributing <- function(
       ))
     }
 
-    invisible(
-      file.copy(
-        system.file(
-          file.path("templates", template_name),
-          package = "rcompendium"
-        ),
-        path_issue,
-        overwrite = TRUE
-      )
+    download_template(
+      slug = paste0("issues/", template_name),
+      filename = template_name,
+      outdir = file.path(path_proj(), ".github", "ISSUE_TEMPLATE")
     )
 
     if (!quiet) {

--- a/R/add_description.R
+++ b/R/add_description.R
@@ -100,17 +100,12 @@ add_description <- function(
   project_name <- get_package_name()
   roxygen2_version <- get_roxygen2_version()
 
-  ## Copy Template ----
+  ## Download template ----
 
-  invisible(
-    file.copy(
-      system.file(
-        file.path("templates", "DESCRIPTION"),
-        package = "rcompendium"
-      ),
-      path,
-      overwrite = TRUE
-    )
+  download_template(
+    slug = "package/DESCRIPTION",
+    filename = "DESCRIPTION",
+    outdir = NULL
   )
 
   ## Change default values (in file) ----

--- a/R/add_dockerfile.R
+++ b/R/add_dockerfile.R
@@ -97,30 +97,18 @@ add_dockerfile <- function(
 
   renv_version <- utils::packageVersion("renv")
 
-  ## Copy Templates ----
+  ## Download templates ----
 
-  invisible(
-    file.copy(
-      system.file(
-        file.path("templates", "Dockerfile"),
-        package = "rcompendium"
-      ),
-      path,
-      overwrite = TRUE
-    )
+  download_template(
+    slug = "docker/Dockerfile",
+    filename = "Dockerfile",
+    outdir = NULL
   )
 
-  path <- file.path(path_proj(), ".dockerignore")
-
-  invisible(
-    file.copy(
-      system.file(
-        file.path("templates", "dockerignore"),
-        package = "rcompendium"
-      ),
-      path,
-      overwrite = TRUE
-    )
+  download_template(
+    slug = "docker/dockerignore",
+    filename = ".dockerignore",
+    outdir = NULL
   )
 
   path <- file.path(path_proj(), "Dockerfile")
@@ -128,8 +116,6 @@ add_dockerfile <- function(
   ## Update default values ----
 
   xfun::gsub_file(path, "{{r_version}}", r_version, fixed = TRUE)
-  xfun::gsub_file(path, "{{given}}", given, fixed = TRUE)
-  xfun::gsub_file(path, "{{family}}", family, fixed = TRUE)
   xfun::gsub_file(path, "{{email}}", email, fixed = TRUE)
 
   ## Install R packages ----

--- a/R/add_github_actions_check.R
+++ b/R/add_github_actions_check.R
@@ -60,7 +60,7 @@ add_github_actions_check <- function(
     }
   }
 
-  ## Copy Template ----
+  ## Download template ----
 
   dir.create(
     file.path(path_proj(), ".github", "workflows"),
@@ -70,14 +70,10 @@ add_github_actions_check <- function(
 
   add_to_buildignore(".github", quiet = FALSE)
 
-  invisible(
-    file.copy(
-      system.file(
-        file.path("templates", "R-CMD-check.yaml"),
-        package = "rcompendium"
-      ),
-      path
-    )
+  download_template(
+    slug = "actions/R-CMD-check.yaml",
+    filename = "R-CMD-check.yaml",
+    outdir = file.path(path_proj(), ".github", "workflows")
   )
 
   if (!quiet) {

--- a/R/add_github_actions_citation.R
+++ b/R/add_github_actions_citation.R
@@ -62,7 +62,7 @@ add_github_actions_citation <- function(
     }
   }
 
-  ## Copy Template ----
+  ## Download template ----
 
   dir.create(
     file.path(path_proj(), ".github", "workflows"),
@@ -72,14 +72,10 @@ add_github_actions_citation <- function(
 
   add_to_buildignore(".github", quiet = FALSE)
 
-  invisible(
-    file.copy(
-      system.file(
-        file.path("templates", "update-citation-cff.yaml"),
-        package = "rcompendium"
-      ),
-      path
-    )
+  download_template(
+    slug = "actions/update-citation-cff.yaml",
+    filename = "update-citation-cff.yaml",
+    outdir = file.path(path_proj(), ".github", "workflows")
   )
 
   if (!quiet) {

--- a/R/add_github_actions_codecov.R
+++ b/R/add_github_actions_codecov.R
@@ -54,7 +54,7 @@ add_github_actions_codecov <- function(
     }
   }
 
-  ## Copy Template ----
+  ## Download template ----
 
   dir.create(
     file.path(path_proj(), ".github", "workflows"),
@@ -64,14 +64,10 @@ add_github_actions_codecov <- function(
 
   add_to_buildignore(".github", quiet = FALSE)
 
-  invisible(
-    file.copy(
-      system.file(
-        file.path("templates", "test-coverage.yaml"),
-        package = "rcompendium"
-      ),
-      path
-    )
+  download_template(
+    slug = "actions/test-coverage.yaml",
+    filename = "test-coverage.yaml",
+    outdir = file.path(path_proj(), ".github", "workflows")
   )
 
   if (!quiet) {

--- a/R/add_github_actions_codemeta.R
+++ b/R/add_github_actions_codemeta.R
@@ -58,7 +58,7 @@ add_github_actions_codemeta <- function(
     }
   }
 
-  ## Copy Template ----
+  ## Download template ----
 
   dir.create(
     file.path(path_proj(), ".github", "workflows"),
@@ -68,14 +68,10 @@ add_github_actions_codemeta <- function(
 
   add_to_buildignore(".github", quiet = FALSE)
 
-  invisible(
-    file.copy(
-      system.file(
-        file.path("templates", "update-codemeta.yaml"),
-        package = "rcompendium"
-      ),
-      path
-    )
+  download_template(
+    slug = "actions/update-codemeta.yaml",
+    filename = "update-codemeta.yaml",
+    outdir = file.path(path_proj(), ".github", "workflows")
   )
 
   if (!quiet) {

--- a/R/add_github_actions_document.R
+++ b/R/add_github_actions_document.R
@@ -43,7 +43,7 @@ add_github_actions_document <- function(
     path_proj(),
     ".github",
     "workflows",
-    "document-package.yaml"
+    "update-Rd-files.yaml"
   )
 
   ## Do not replace current file but open it if required ----
@@ -51,7 +51,7 @@ add_github_actions_document <- function(
   if (file.exists(path) && !overwrite) {
     if (!open) {
       stop(
-        "An '.github/workflows/document-package.yaml' file is already ",
+        "An '.github/workflows/update-Rd-files.yaml' file is already ",
         "present. If you want to replace it, please use `overwrite = TRUE`."
       )
     } else {
@@ -60,7 +60,7 @@ add_github_actions_document <- function(
     }
   }
 
-  ## Copy Template ----
+  ## Download template ----
 
   dir.create(
     file.path(path_proj(), ".github", "workflows"),
@@ -70,20 +70,16 @@ add_github_actions_document <- function(
 
   add_to_buildignore(".github", quiet = FALSE)
 
-  invisible(
-    file.copy(
-      system.file(
-        file.path("templates", "document-package.yaml"),
-        package = "rcompendium"
-      ),
-      path
-    )
+  download_template(
+    slug = "actions/update-Rd-files.yaml",
+    filename = "update-Rd-files.yaml",
+    outdir = file.path(path_proj(), ".github", "workflows")
   )
 
   if (!quiet) {
     ui_done(paste0(
       "Writing ",
-      "{ui_value('.github/workflows/document-package.yaml')} ",
+      "{ui_value('.github/workflows/update-Rd-files.yaml')} ",
       "file"
     ))
   }

--- a/R/add_github_actions_pkgdown.R
+++ b/R/add_github_actions_pkgdown.R
@@ -56,7 +56,7 @@ add_github_actions_pkgdown <- function(
     }
   }
 
-  ## Copy Template ----
+  ## Download template ----
 
   dir.create(
     file.path(path_proj(), ".github", "workflows"),
@@ -66,14 +66,10 @@ add_github_actions_pkgdown <- function(
 
   add_to_buildignore(".github", quiet = FALSE)
 
-  invisible(
-    file.copy(
-      system.file(
-        file.path("templates", "pkgdown.yaml"),
-        package = "rcompendium"
-      ),
-      path
-    )
+  download_template(
+    slug = "actions/pkgdown.yaml",
+    filename = "pkgdown.yaml",
+    outdir = file.path(path_proj(), ".github", "workflows")
   )
 
   if (!quiet) {

--- a/R/add_github_actions_render.R
+++ b/R/add_github_actions_render.R
@@ -55,7 +55,7 @@ add_github_actions_render <- function(
     }
   }
 
-  ## Copy Template ----
+  ## Download template ----
 
   dir.create(
     file.path(path_proj(), ".github", "workflows"),
@@ -65,14 +65,10 @@ add_github_actions_render <- function(
 
   add_to_buildignore(".github", quiet = FALSE)
 
-  invisible(
-    file.copy(
-      system.file(
-        file.path("templates", "render-README.yaml"),
-        package = "rcompendium"
-      ),
-      path
-    )
+  download_template(
+    slug = "actions/render-README.yaml",
+    filename = "render-README.yaml",
+    outdir = file.path(path_proj(), ".github", "workflows")
   )
 
   if (!quiet) {

--- a/R/add_license.R
+++ b/R/add_license.R
@@ -121,21 +121,18 @@ add_license <- function(
     ))
   }
 
-  ## Copy LICENSE file (MIT) ----
+  ## Download LICENSE file (MIT) ----
 
   if (license == "MIT") {
-    invisible(
-      file.copy(
-        system.file(
-          file.path("licenses", "copyright-mit"),
-          package = "rcompendium"
-        ),
-        file.path(path, "LICENSE"),
-        overwrite = TRUE
-      )
+    download_template(
+      slug = "licenses/copyright-mit",
+      filename = "LICENSE",
+      outdir = NULL
     )
 
-    if (!quiet) ui_done("Writing {ui_value('LICENSE')} file")
+    if (!quiet) {
+      ui_done("Writing {ui_value('LICENSE')} file")
+    }
   } else {
     if (file.exists(file.path(path, "LICENSE"))) {
       invisible(file.remove(file.path(path, "LICENSE")))
@@ -146,12 +143,10 @@ add_license <- function(
 
   license_file <- paste("license", licenses[license_id, "file"], sep = "-")
 
-  invisible(
-    file.copy(
-      system.file(file.path("licenses", license_file), package = "rcompendium"),
-      file.path(path, "LICENSE.md"),
-      overwrite = TRUE
-    )
+  download_template(
+    slug = paste0("licenses/", license_file),
+    filename = "LICENSE.md",
+    outdir = NULL
   )
 
   if (!quiet) {

--- a/R/add_makefile.R
+++ b/R/add_makefile.R
@@ -71,14 +71,12 @@ add_makefile <- function(
   project_name <- get_package_name()
   today <- format(Sys.time(), "%Y/%m/%d")
 
-  ## Copy Template ----
+  ## Download template ----
 
-  invisible(
-    file.copy(
-      system.file(file.path("templates", "make.R"), package = "rcompendium"),
-      path,
-      overwrite = TRUE
-    )
+  download_template(
+    slug = "others/make.R",
+    filename = "make.R",
+    outdir = NULL
   )
 
   ## Update default values ----

--- a/R/add_package_doc.R
+++ b/R/add_package_doc.R
@@ -52,15 +52,10 @@ add_package_doc <- function(open = TRUE, overwrite = FALSE, quiet = FALSE) {
     dir.create(file.path(path_proj(), "R"), showWarnings = FALSE)
   }
 
-  invisible(
-    file.copy(
-      system.file(
-        file.path("templates", "package-package.R"),
-        package = "rcompendium"
-      ),
-      path,
-      overwrite = TRUE
-    )
+  download_template(
+    slug = "package/package-package.R",
+    filename = filename,
+    outdir = file.path(path_proj(), "R")
   )
 
   if (!quiet) {

--- a/R/add_readme_rmd.R
+++ b/R/add_readme_rmd.R
@@ -102,26 +102,16 @@ add_readme_rmd <- function(
   ## Copy Template ----
 
   if (type == "package") {
-    invisible(
-      file.copy(
-        system.file(
-          file.path("templates", "README-pkg.Rmd"),
-          package = "rcompendium"
-        ),
-        path,
-        overwrite = TRUE
-      )
+    download_template(
+      slug = "readme/README-package.Rmd",
+      filename = "README.Rmd",
+      outdir = NULL
     )
   } else {
-    invisible(
-      file.copy(
-        system.file(
-          file.path("templates", "README-comp.Rmd"),
-          package = "rcompendium"
-        ),
-        path,
-        overwrite = TRUE
-      )
+    download_template(
+      slug = "readme/README-compendium.Rmd",
+      filename = "README.Rmd",
+      outdir = NULL
     )
   }
 

--- a/R/add_testthat.R
+++ b/R/add_testthat.R
@@ -21,18 +21,13 @@ add_testthat <- function() {
   if (!file.exists(file.path(path_proj(), "tests", "testthat.R"))) {
     usethis::use_testthat()
 
-    path <- file.path(path_proj(), "tests", "testthat", "test-demo.R")
+    path <- file.path(path_proj(), "tests", "testthat", "test-print_msg.R")
 
     if (!file.exists(path)) {
-      invisible(
-        file.copy(
-          system.file(
-            file.path("templates", "test-demo.R"),
-            package = "rcompendium"
-          ),
-          path,
-          overwrite = TRUE
-        )
+      download_template(
+        slug = "package/test-print_msg.R",
+        filename = "test-print_msg.R",
+        outdir = file.path(path_proj(), "tests", "testthat")
       )
     }
   }

--- a/R/add_to_gitignore.R
+++ b/R/add_to_gitignore.R
@@ -34,14 +34,10 @@ add_to_gitignore <- function(x, open = FALSE, quiet = FALSE) {
   ## Copy Template ----
 
   if (!file.exists(path)) {
-    invisible(
-      file.copy(
-        system.file(
-          file.path("templates", "gitignore"),
-          package = "rcompendium"
-        ),
-        path
-      )
+    download_template(
+      slug = "git/gitignore",
+      filename = ".gitignore",
+      outdir = NULL
     )
 
     if (!quiet) ui_done("Writing {ui_value('.gitignore')} file")

--- a/R/add_vignette.R
+++ b/R/add_vignette.R
@@ -89,15 +89,10 @@ add_vignette <- function(
     dir.create(file.path(path_proj(), "vignettes"), showWarnings = FALSE)
   }
 
-  invisible(
-    file.copy(
-      system.file(
-        file.path("templates", "package-vignette.Rmd"),
-        package = "rcompendium"
-      ),
-      path,
-      overwrite = TRUE
-    )
+  download_template(
+    slug = "package/package-vignette.Rmd",
+    filename = ".gitignore",
+    outdir = file.path(path_proj(), "vignettes")
   )
 
   ## Replace default values ----
@@ -197,5 +192,6 @@ add_vignette <- function(
   if (open) {
     edit_file(path)
   }
+
   invisible(NULL)
 }

--- a/R/new_compendium.R
+++ b/R/new_compendium.R
@@ -485,16 +485,11 @@ new_compendium <- function(
 
   ## Demo R function ----
 
-  if (!file.exists(file.path(path_proj(), "R", "fun-demo.R"))) {
-    invisible(
-      file.copy(
-        system.file(
-          file.path("templates", "fun-demo.R"),
-          package = "rcompendium"
-        ),
-        file.path(path_proj(), "R", "fun-demo.R"),
-        overwrite = overwrite
-      )
+  if (!file.exists(file.path(path_proj(), "R", "print_msg.R"))) {
+    download_template(
+      slug = "package/print_msg.R",
+      filename = "print_msg.R",
+      outdir = file.path(path_proj(), "R")
     )
   }
 

--- a/R/new_package.R
+++ b/R/new_package.R
@@ -584,16 +584,11 @@ new_package <- function(
 
   ## Demo R function ----
 
-  if (!file.exists(file.path(path_proj(), "R", "fun-demo.R"))) {
-    invisible(
-      file.copy(
-        system.file(
-          file.path("templates", "fun-demo.R"),
-          package = "rcompendium"
-        ),
-        file.path(path_proj(), "R", "fun-demo.R"),
-        overwrite = overwrite
-      )
+  if (!file.exists(file.path(path_proj(), "R", "print_msg.R"))) {
+    download_template(
+      slug = "package/print_msg.R",
+      filename = "print_msg.R",
+      outdir = file.path(path_proj(), "R")
     )
   }
 

--- a/R/utils-io.R
+++ b/R/utils-io.R
@@ -171,7 +171,7 @@ add_sticker <- function(type, overwrite = FALSE, quiet = FALSE) {
       path_proj(),
       "man",
       "figures",
-      paste0(type, "-sticker.png")
+      "logo.png"
     )
 
     pathdir <- file.path("man", "figures")
@@ -180,7 +180,7 @@ add_sticker <- function(type, overwrite = FALSE, quiet = FALSE) {
       path_proj(),
       "figures",
       "readme",
-      paste0(type, "-sticker.png")
+      "logo.png"
     )
 
     pathdir <- file.path("figures", "readme")
@@ -191,8 +191,7 @@ add_sticker <- function(type, overwrite = FALSE, quiet = FALSE) {
       "A '",
       pathdir,
       "/",
-      type,
-      "-sticker.png' is already present. ",
+      "logo.png' is already present. ",
       "If you want to replace it, please use `overwrite = TRUE`."
     ))
   }
@@ -205,15 +204,10 @@ add_sticker <- function(type, overwrite = FALSE, quiet = FALSE) {
     )
   }
 
-  invisible(
-    file.copy(
-      system.file(
-        file.path("templates", paste0(type, "-sticker.png")),
-        package = "rcompendium"
-      ),
-      path,
-      overwrite = TRUE
-    )
+  download_template(
+    slug = paste0("hexsticker/", type, "-sticker.png"),
+    filename = "logo.png",
+    outdir = file.path(path_proj(), pathdir)
   )
 
   if (type == "package") {
@@ -228,15 +222,10 @@ add_sticker <- function(type, overwrite = FALSE, quiet = FALSE) {
     path <- file.path(path_proj(), "inst", "package-sticker", "r_logo.png")
 
     if (!file.exists(path)) {
-      invisible(
-        file.copy(
-          system.file(
-            file.path("templates", "r_logo.png"),
-            package = "rcompendium"
-          ),
-          path,
-          overwrite = FALSE
-        )
+      download_template(
+        slug = "hexsticker/r_logo.png",
+        filename = "r_logo.png",
+        outdir = file.path(path_proj(), "inst", "package-sticker")
       )
     }
 
@@ -244,19 +233,14 @@ add_sticker <- function(type, overwrite = FALSE, quiet = FALSE) {
       path_proj(),
       "inst",
       "package-sticker",
-      "package-sticker.R"
+      "create_package_sticker.R"
     )
 
     if (!file.exists(path)) {
-      invisible(
-        file.copy(
-          system.file(
-            file.path("templates", "package-sticker.R"),
-            package = "rcompendium"
-          ),
-          path,
-          overwrite = FALSE
-        )
+      download_template(
+        slug = "hexsticker/create_package_sticker.R",
+        filename = "create_package_sticker.R",
+        outdir = file.path(path_proj(), "inst", "package-sticker")
       )
     }
   }
@@ -308,7 +292,7 @@ gsub_in_file <- function(file, ...) {
 
 
 #' **URL of the template GitHub repository**
-#' 
+#'
 #' @noRd
 
 template_url <- function() {
@@ -317,15 +301,15 @@ template_url <- function() {
 
 
 #' **Helper function to download a file from the template GitHub repo**
-#' 
+#'
 #' @param slug a character of length 1. End of the file URL
 #'   (e.g. `package/CITATION`)
-#' 
+#'
 #' @param filename a character of length 1. The name of the file stored locally.
-#' 
-#' @param outdir a character of length 1. The name of the folder to save the 
+#'
+#' @param outdir a character of length 1. The name of the folder to save the
 #'   file in. Defaut is `NULL` (i.e. root of the project).
-#' 
+#'
 #' @noRd
 
 download_template <- function(slug, filename, outdir = NULL) {

--- a/R/utils-io.R
+++ b/R/utils-io.R
@@ -305,3 +305,48 @@ gsub_in_file <- function(file, ...) {
 
   invisible(NULL)
 }
+
+
+#' **URL of the template GitHub repository**
+#' 
+#' @noRd
+
+template_url <- function() {
+  "https://raw.githubusercontent.com/FRBCesab/r-templates/refs/heads/main/"
+}
+
+
+#' **Helper function to download a file from the template GitHub repo**
+#' 
+#' @param slug a character of length 1. End of the file URL
+#'   (e.g. `package/CITATION`)
+#' 
+#' @param filename a character of length 1. The name of the file stored locally.
+#' 
+#' @param outdir a character of length 1. The name of the folder to save the 
+#'   file in. Defaut is `NULL` (i.e. root of the project).
+#' 
+#' @noRd
+
+download_template <- function(slug, filename, outdir = NULL) {
+  stop_if_not_string(slug, filename)
+
+  if (!is.null(outdir)) {
+    stop_if_not_string(outdir)
+  }
+
+  if (is.null(outdir)) {
+    destfile <- file.path(path_proj(), filename)
+  } else {
+    destfile <- file.path(path_proj(), outdir, filename)
+  }
+
+  utils::download.file(
+    url = paste0(template_url(), slug),
+    destfile = destfile,
+    mode = "wb",
+    quiet = TRUE
+  )
+
+  invisible(NULL)
+}


### PR DESCRIPTION
This PR is linked to #83 and simplifies the usage of templates. Instead of copying file templates directly from the package, `rcompendium` now downloads templates from GitHub.

All templates have been moved to <https://github.com/FRBCesab/r-templates> and are now organized by category.

This PR introduces `download_template()`, a generic function used to download any template from GitHub. It replaces the `file.copy()` call in all `add_*()` & `new_*()` functions.