### PR TITLE
Feat: Include a dependabot.yaml

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * **New features**
 
   * Add a new internal function `download_template()` to download a file template from the GitHub repo <https://github.com/frbcesab/r-templates> ([#85](https://github.com/FRBCesab/rcompendium/pull/85))
+  * `add_github_actions_*()` automatically creates a `.github/dependabot.yaml` file if one GitHub Action is set up ([#89](https://github.com/FRBCesab/rcompendium/pull/89))
 
 * **Bug fixes**
 

--- a/R/add_github_action.R
+++ b/R/add_github_action.R
@@ -10,8 +10,7 @@
 #' hosted on a different repository
 #' \url{https://github.com/FRBCesab/r-templates/tree/main/actions}.
 #'
-#' Configuration files will be written in `.github/workflows/`
-#' (or in `.github/` for the `dependabot.yaml` action).
+#' Configuration files will be written in `.github/workflows/`.
 #'
 #' @param name A character of length 1. The name of the GitHub Action to set up.
 #'   Run [get_available_gh_actions()] to list available GitHub Actions.
@@ -64,10 +63,11 @@
 #' is modified. This action will commit and push the updated `codemeta.json` to
 #' the main branch. User need to fetch the new version.
 #'
-#' - `dependabot`: this action will be triggered once a week to check for
-#' dependency updates (used by the GitHub Actions of the repository). If an
-#' update is available, this bot will open a Pull Request and user will be
-#' invited to review changes.
+#' If one of these GitHub Actions is added to the project, this function will
+#' also create a `dependabot.yaml` file in `.github/`. This action will be
+#' triggered once a week to check for dependency updates (used by any GitHub
+#' Action of the repository). If an update is available, this bot will open a
+#' Pull Request and user will be invited to review changes.
 #'
 #' @return No return value.
 #'
@@ -111,18 +111,11 @@ add_github_action <- function(
     )
   }
 
-  ## Get action file name ----
+  ## Create file name & path ----
 
   action <- available_actions[which(tolower(available_actions) == action)]
   filename <- paste0(action, ".yaml")
-
-  ## Define final directory ----
-
-  if (action == "dependabot") {
-    path <- file.path(".github")
-  } else {
-    path <- file.path(".github", "workflows")
-  }
+  path <- file.path(".github", "workflows")
 
   ## Do not replace current file but open it if required ----
 
@@ -168,6 +161,27 @@ add_github_action <- function(
 
   if (open) {
     edit_file(path)
+  }
+
+  ## Add dependabot ----
+
+  filename <- "dependabot.yaml"
+  path <- file.path(".github")
+
+  if (!file.exists(file.path(path_proj(), path, filename))) {
+    download_template(
+      slug = paste0("actions/", filename),
+      filename = filename,
+      outdir = path
+    )
+
+    if (!quiet) {
+      ui_done(paste0(
+        "Writing {ui_value('",
+        file.path(path, filename),
+        "')} file"
+      ))
+    }
   }
 
   invisible(NULL)

--- a/R/get_available_gh_actions.R
+++ b/R/get_available_gh_actions.R
@@ -25,5 +25,6 @@ get_available_gh_actions <- function() {
   )
 
   actions <- unlist(lapply(actions, function(x) x[["name"]]))
+  actions <- actions[-which(actions == "dependabot.yaml")]
   gsub("\\.(yaml|yml)$", "", actions)
 }

--- a/man/add_github_action.Rd
+++ b/man/add_github_action.Rd
@@ -32,8 +32,7 @@ Available workflows are derived from
 hosted on a different repository
 \url{https://github.com/FRBCesab/r-templates/tree/main/actions}.
 
-Configuration files will be written in \verb{.github/workflows/}
-(or in \verb{.github/} for the \code{dependabot.yaml} action).
+Configuration files will be written in \verb{.github/workflows/}.
 }
 \details{
 Here is a list of commonly used GitHub Actions that will be triggered after
@@ -66,11 +65,13 @@ file for software (not only R packages). This action is triggered if
 the \code{DESCRIPTION} file and/or the \code{inst/CITATION} file and/or the \code{README.md}
 is modified. This action will commit and push the updated \code{codemeta.json} to
 the main branch. User need to fetch the new version.
-\item \code{dependabot}: this action will be triggered once a week to check for
-dependency updates (used by the GitHub Actions of the repository). If an
-update is available, this bot will open a Pull Request and user will be
-invited to review changes.
 }
+
+If one of these GitHub Actions is added to the project, this function will
+also create a \code{dependabot.yaml} file in \verb{.github/}. This action will be
+triggered once a week to check for dependency updates (used by any GitHub
+Action of the repository). If an update is available, this bot will open a
+Pull Request and user will be invited to review changes.
 }
 \examples{
 \dontrun{


### PR DESCRIPTION
This PR is linked to #88 and adds a `.github/dependabt.yaml` if any GH Action is created while calling `add_github_action()`.