### PR TITLE
Update installation instructions for rcompendium

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -71,14 +71,13 @@ This package heavily relies on the R packages
 You can install the stable version from [CRAN](https://cran.r-project.org/) with:
 
 ```{r eval=FALSE}
-## Install stable version of {rcompendium} from CRAN ----
 install.packages("rcompendium")
 ```
 
 Or using [`pak`](https://pak.r-lib.org/):
 
 ```{r eval=FALSE}
-## Install stable version of {rcompendium} from CRAN ----
+## install.packages("pak")
 pak::pak("rcompendium")
 ```
 
@@ -86,17 +85,19 @@ pak::pak("rcompendium")
 
 You can install the development version from [GitHub](https://github.com/FRBCesab/rcompendium) with:
 
-```{r eval=FALSE}
-## Install dev version of {rcompendium} from GitHub ----
-remotes::install_github("FRBCesab/rcompendium")
-```
+- Using [`remotes`](https://remotes.r-lib.org/):
 
-Or using [`pak`](https://pak.r-lib.org/):
+  ```{r eval=FALSE}
+  ## install.packages("remotes")
+  remotes::install_github("FRBCesab/rcompendium")
+  ```
 
-```{r eval=FALSE}
-## Install dev version of {rcompendium} from GitHub ----
-pak::pak("FRBCesab/rcompendium")
-```
+- Or using [`pak`](https://pak.r-lib.org/):
+
+  ```{r eval=FALSE}
+  ## install.packages("pak")
+  pak::pak("FRBCesab/rcompendium")
+  ```
 
 ## Usage
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -64,38 +64,41 @@ This package heavily relies on the R packages
 [Hadley Wickham & Jenny Bryan](https://r-pkgs.org) and 
 [Ben Marwick](https://peerj.com/preprints/3192/).
 
-
-
-
 ## Installation
 
-
+### Stable version
 
 You can install the stable version from [CRAN](https://cran.r-project.org/) with:
 
 ```{r eval=FALSE}
-## Install stable version of < rcompendium > from CRAN ----
+## Install stable version of {rcompendium} from CRAN ----
 install.packages("rcompendium")
 ```
 
-
-Or you can install the development version from [GitHub](https://github.com/) with:
+Or using [`pak`](https://pak.r-lib.org/):
 
 ```{r eval=FALSE}
-## Install < remotes > package (if not already installed) ----
-if (!requireNamespace("remotes", quietly = TRUE)) {
-  install.packages("remotes")
-}
+## Install stable version of {rcompendium} from CRAN ----
+pak::pak("rcompendium")
+```
 
-## Install dev version of < rcompendium > from GitHub ----
+### Development version
+
+You can install the development version from [GitHub](https://github.com/FRBCesab/rcompendium) with:
+
+```{r eval=FALSE}
+## Install dev version of {rcompendium} from GitHub ----
 remotes::install_github("FRBCesab/rcompendium")
 ```
 
+Or using [`pak`](https://pak.r-lib.org/):
 
+```{r eval=FALSE}
+## Install dev version of {rcompendium} from GitHub ----
+pak::pak("FRBCesab/rcompendium")
+```
 
 ## Usage
-
-
 
 Please read the 
 [Get started](https://frbcesab.github.io/rcompendium/articles/rcompendium.html) vignette
@@ -108,11 +111,7 @@ Others available vignettes:
 - [Developing a Package](https://frbcesab.github.io/rcompendium/articles/developing_a_package.html)
 - [Working with a Compendium](https://frbcesab.github.io/rcompendium/articles/working_with_a_compendium.html)
 
-
-
 ## Citation
-
-
 
 Please cite this package as: 
 
@@ -135,11 +134,7 @@ citation("rcompendium")
 ## }
 ```
 
-
-
 ## Contributing
-
-
 
 All types of contributions are encouraged and valued. For more information, 
 check out our [Contribution Guidelines](https://github.com/FRBCesab/rcompendium/blob/main/CONTRIBUTING.md).
@@ -148,12 +143,7 @@ Please note that the `rcompendium` project is released with a
 [Contributor Code of Conduct](https://contributor-covenant.org/version/2/1/CODE_OF_CONDUCT.html). 
 By contributing to this project, you agree to abide by its terms.
 
-
-
-
 ## Colophon
-
-
 
 This package is the result of intense discussions and feedbacks from the training 
 course [Reproducible Research in Computational Ecology](https://rdatatoolbox.github.io/). 

--- a/README.md
+++ b/README.md
@@ -54,25 +54,38 @@ Marwick](https://peerj.com/preprints/3192/).
 
 ## Installation
 
+### Stable version
+
 You can install the stable version from
 [CRAN](https://cran.r-project.org/) with:
 
 ``` r
-## Install stable version of < rcompendium > from CRAN ----
+## Install stable version of {rcompendium} from CRAN ----
 install.packages("rcompendium")
 ```
 
-Or you can install the development version from
-[GitHub](https://github.com/) with:
+Or using [`pak`](https://pak.r-lib.org/):
 
 ``` r
-## Install < remotes > package (if not already installed) ----
-if (!requireNamespace("remotes", quietly = TRUE)) {
-  install.packages("remotes")
-}
+## Install stable version of {rcompendium} from CRAN ----
+pak::pak("rcompendium")
+```
 
-## Install dev version of < rcompendium > from GitHub ----
+### Development version
+
+You can install the development version from
+[GitHub](https://github.com/FRBCesab/rcompendium) with:
+
+``` r
+## Install dev version of {rcompendium} from GitHub ----
 remotes::install_github("FRBCesab/rcompendium")
+```
+
+Or using [`pak`](https://pak.r-lib.org/):
+
+``` r
+## Install dev version of {rcompendium} from GitHub ----
+pak::pak("FRBCesab/rcompendium")
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -60,14 +60,13 @@ You can install the stable version from
 [CRAN](https://cran.r-project.org/) with:
 
 ``` r
-## Install stable version of {rcompendium} from CRAN ----
 install.packages("rcompendium")
 ```
 
 Or using [`pak`](https://pak.r-lib.org/):
 
 ``` r
-## Install stable version of {rcompendium} from CRAN ----
+## install.packages("pak")
 pak::pak("rcompendium")
 ```
 
@@ -76,17 +75,19 @@ pak::pak("rcompendium")
 You can install the development version from
 [GitHub](https://github.com/FRBCesab/rcompendium) with:
 
-``` r
-## Install dev version of {rcompendium} from GitHub ----
-remotes::install_github("FRBCesab/rcompendium")
-```
+- Using [`remotes`](https://remotes.r-lib.org/):
 
-Or using [`pak`](https://pak.r-lib.org/):
+  ``` r
+  ## install.packages("remotes")
+  remotes::install_github("FRBCesab/rcompendium")
+  ```
 
-``` r
-## Install dev version of {rcompendium} from GitHub ----
-pak::pak("FRBCesab/rcompendium")
-```
+- Or using [`pak`](https://pak.r-lib.org/):
+
+  ``` r
+  ## install.packages("pak")
+  pak::pak("FRBCesab/rcompendium")
+  ```
 
 ## Usage
 


### PR DESCRIPTION
This PR clarify installation commands for both stable and development versions of rcompendium. Include usage of 'pak' for package installation.