### PR TITLE
Refactor add_citation()

### DIFF
--- a/R/add_citation.R
+++ b/R/add_citation.R
@@ -31,7 +31,6 @@
 #' \dontrun{
 #' add_citation()
 #' readCitationFile("inst/CITATION")
-#' citation("pkg")    # If you have installed your package <pkg>
 #' }
 
 add_citation <- function(
@@ -44,80 +43,26 @@ add_citation <- function(
 ) {
   stop_if_not_logical(open, overwrite, quiet)
 
-  path <- file.path(path_proj(), "inst", "CITATION")
+  full_path <- build_full_path("inst", "CITATION")
+  rel_path <- build_rel_path("inst", "CITATION")
 
-  ## Do not replace current file but open it if required ----
+  assert_file_not_exists_or_overwrite(rel_path, overwrite)
 
-  if (file.exists(path) && !overwrite) {
-    if (!open) {
-      stop(
-        "An 'inst/CITATION' file is already present. If you want to ",
-        "replace it, please use `overwrite = TRUE`."
-      )
-    } else {
-      edit_file(path)
-      return(invisible(NULL))
-    }
-  }
-
-  ## Get fields values ----
-
-  if (is.null(given)) {
-    given <- getOption("given")
-  }
-  if (is.null(family)) {
-    family <- getOption("family")
-  }
-
-  if (!is.null(organisation)) {
-    github <- organisation
-  } else {
-    github <- gh::gh_whoami()$"login"
-
-    if (is.null(github)) {
-      stop(
-        "Unable to find GitHub username. Please run ",
-        "`?gert::git_config_global` for more information."
-      )
-    }
-  }
-
-  stop_if_not_string(given, family, github)
-
-  project_name <- get_package_name()
-  pkg_version <- get_package_version()
-  year <- format(Sys.Date(), "%Y")
-
-  ## Download template ----
-
-  if (!dir.exists(file.path(path_proj(), "inst"))) {
-    dir.create(file.path(path_proj(), "inst"), showWarnings = FALSE)
-  }
-
-  download_template(
-    slug = "package/CITATION",
-    filename = "CITATION",
-    outdir = file.path(path_proj(), "inst")
+  meta <- resolve_project_meta(
+    given = given,
+    family = family,
+    organisation = organisation
   )
 
-  ## Change defaults values ----
+  if (should_create_file(full_path, overwrite)) {
+    ensure_dir_exists(dirname(full_path))
 
-  xfun::gsub_file(path, "{{project_name}}", project_name, fixed = TRUE)
-  xfun::gsub_file(path, "{{pkg_version}}", pkg_version, fixed = TRUE)
-  xfun::gsub_file(path, "{{year}}", year, fixed = TRUE)
-  xfun::gsub_file(path, "{{given}}", given, fixed = TRUE)
-  xfun::gsub_file(path, "{{family}}", family, fixed = TRUE)
-  xfun::gsub_file(path, "{{github}}", github, fixed = TRUE)
+    create_citation_template(rel_path, meta)
 
-  ## Messages ----
-
-  if (!quiet) {
-    ui_done("Writing {ui_value('inst/CITATION')} file")
+    ui_file_written(rel_path, quiet)
   }
 
-  if (open) {
-    edit_file(path)
-  }
+  open_file_if_needed(full_path, open)
 
   invisible(NULL)
 }

--- a/R/add_citation.R
+++ b/R/add_citation.R
@@ -55,6 +55,9 @@ add_citation <- function(
     organisation = organisation
   )
 
+  stop_if_null_or_empty(meta$given, "given")
+  stop_if_null_or_empty(meta$family, "family")
+
   if (should_create_file(full_path, overwrite)) {
     ensure_dir_exists(dirname(full_path))
 

--- a/R/add_citation.R
+++ b/R/add_citation.R
@@ -41,6 +41,7 @@ add_citation <- function(
   overwrite = FALSE,
   quiet = FALSE
 ) {
+  stop_if_not_project()
   stop_if_not_logical(open, overwrite, quiet)
 
   full_path <- build_full_path("inst", "CITATION")

--- a/R/utils-new.R
+++ b/R/utils-new.R
@@ -1,0 +1,200 @@
+#' Get project full path
+#' @noRd
+get_proj_path <- function() usethis::proj_get()
+
+
+#' Build an absolute path
+#' @param ... one or several folder/file names
+#' @noRd
+build_full_path <- function(...) {
+  file.path(get_proj_path(), ...)
+}
+
+
+#' Build a path relative to the project root
+#' @param ... one or several folder/file names
+#' @noRd
+build_rel_path <- function(...) {
+  file.path(...)
+}
+
+
+#' Error if a file exists and if overwrite is FALSE
+#' @param path a character of length of 1. The relative path of the file
+#' @param overwrite a logical of length 1.
+#' @noRd
+assert_file_not_exists_or_overwrite <- function(path, overwrite) {
+  if (file.exists(build_full_path(path)) && !overwrite) {
+    stop(
+      paste0(
+        "The file '",
+        path,
+        "' already exists. ",
+        "To replace it, please use `overwrite = TRUE`."
+      ),
+      call. = FALSE
+    )
+  }
+
+  invisible(NULL)
+}
+
+
+#' Retrieve and assert project metadata
+#' @param ... any metadata options (given, email, etc.) or empty
+#' @noRd
+resolve_project_meta <- function(...) {
+  args <- list(...)
+
+  given <- args$given %||% getOption("given")
+  family <- args$family %||% getOption("family")
+  email <- args$email %||% getOption("email")
+  orcid <- args$orcid %||% getOption("orcid")
+
+  stop_if_null_or_empty(given, "given")
+  stop_if_null_or_empty(family, "family")
+
+  list(
+    given = given,
+    family = family,
+    email = email,
+    orcid = orcid,
+    github_user = get_github_user(),
+    github_account = resolve_github_account(args$organisation),
+    package_name = get_package_name(),
+    year = format(Sys.Date(), "%Y")
+  )
+}
+
+
+#' Retrieve GitHub account of the repo
+#' @param organisation a character of length 1 (optional). The name of the GH
+#'   organisation. If `NULL` (default), the user account is used.
+#' @noRd
+resolve_github_account <- function(organisation = NULL) {
+  if (!is.null(organisation)) {
+    stop_if_not_string(organisation)
+    return(organisation)
+  }
+
+  get_github_user()
+}
+
+
+#' Retrieve GitHub account name
+#' @noRd
+get_github_user <- function() {
+  github <- gh::gh_whoami()$"login"
+
+  if (is.null(github)) {
+    stop(
+      "Unable to find GitHub username. Please run ",
+      "`?gh::gh_whoami` for more information."
+    )
+  }
+
+  github
+}
+
+
+#' Return TRUE if a file does not exist or if overwrite is TRUE
+#' @param path a character of length of 1. The absolute path of the file.
+#' @param overwrite a logical of length 1.
+#' @noRd
+should_create_file <- function(path, overwrite) {
+  !file.exists(path) || overwrite
+}
+
+
+#' Create a directory if required
+#' @param path a character of length of 1. The absolute path of the directory.
+#' @noRd
+ensure_dir_exists <- function(path) {
+  if (!dir.exists(path)) {
+    dir.create(path, recursive = TRUE)
+  }
+
+  invisible(NULL)
+}
+
+
+#' Download the CITATION file and replace default values
+#' @param path a character of length of 1. The absolute path of the file.
+#' @param meta a list of the project metadata.
+#' @noRd
+create_citation_template <- function(path, meta) {
+  download_template(
+    slug = "package/CITATION",
+    filename = basename(path),
+    outdir = dirname(path)
+  )
+
+  populate_citation_template(build_full_path(path), meta)
+
+  invisible(NULL)
+}
+
+
+#' Replace default values in the CITATION file
+#' @param path a character of length of 1. The absolute path of the file.
+#' @param meta a list of the project metadata.
+#' @noRd
+populate_citation_template <- function(path, meta) {
+  xfun::gsub_file(path, "{{project_name}}", meta$package_name, fixed = TRUE)
+  xfun::gsub_file(path, "{{given}}", meta$given, fixed = TRUE)
+  xfun::gsub_file(path, "{{family}}", meta$family, fixed = TRUE)
+  xfun::gsub_file(path, "{{github}}", meta$github_account, fixed = TRUE)
+  xfun::gsub_file(path, "{{year}}", meta$year, fixed = TRUE)
+
+  invisible(NULL)
+}
+
+
+#' Inform user that a file has been written
+#' @param path a character of length of 1. The absolute path of the file.
+#' @param quiet a logical of length 1.
+#' @noRd
+ui_file_written <- function(path, quiet = FALSE) {
+  if (!quiet) {
+    cli::cli_alert_success("Writing {.file {path}} file")
+  }
+
+  invisible(NULL)
+}
+
+
+#' Open a file if required
+#' @param path a character of length of 1. The absolute path of the file.
+#' @param open a logical of length 1.
+#' @noRd
+open_file_if_needed <- function(path, open) {
+  if (open) {
+    edit_file(path)
+  }
+
+  invisible(NULL)
+}
+
+
+#' Helper: if x is NULL then y
+#' @noRd
+`%||%` <- function(x, y) {
+  if (is.null(x)) y else x
+}
+
+
+#' Error if an argument is NULL or empty
+#' @noRd
+stop_if_null_or_empty <- function(value, name) {
+  if (is.null(value) || identical(value, "") || length(value) == 0) {
+    stop(
+      paste0(
+        "Argument '",
+        name,
+        "' is required but is NULL or empty."
+      )
+    )
+  }
+
+  invisible(NULL)
+}

--- a/R/utils-new.R
+++ b/R/utils-new.R
@@ -51,9 +51,6 @@ resolve_project_meta <- function(...) {
   email <- args$email %||% getOption("email")
   orcid <- args$orcid %||% getOption("orcid")
 
-  stop_if_null_or_empty(given, "given")
-  stop_if_null_or_empty(family, "family")
-
   list(
     given = given,
     family = family,

--- a/R/utils-new.R
+++ b/R/utils-new.R
@@ -198,3 +198,27 @@ stop_if_null_or_empty <- function(value, name) {
 
   invisible(NULL)
 }
+
+
+#' Error if the current working directory is not a project/package
+#' @noRd
+stop_if_not_project <- function() {
+  markers <- c(
+    "DESCRIPTION",
+    ".git",
+    ".Rproj",
+    ".here",
+    "renv.lock",
+    ".vscode/settings.json"
+  )
+
+  if (all(!file.exists(markers))) {
+    stop(paste0(
+      "The path '",
+      getwd(),
+      "' does not appear to be inside a project or package."
+    ))
+  }
+
+  invisible(NULL)
+}

--- a/man/add_citation.Rd
+++ b/man/add_citation.Rd
@@ -46,7 +46,6 @@ edit by hand some information (title, version, etc.).
 \dontrun{
 add_citation()
 readCitationFile("inst/CITATION")
-citation("pkg")    # If you have installed your package <pkg>
 }
 }
 \seealso{


### PR DESCRIPTION
Refactor `add_citation()` and introducing a new set of helper functions:

- `build_full_path()`
- `build_rel_path()`
- `stop_if_not_project()`
- `assert_file_not_exists_or_overwrite()`
- `resolve_project_meta()`
- `resolve_github_account()`
- `get_github_user()`
- `should_create_file()`
- `ensure_dir_exists()`
- `create_citation_template()`
- `populate_citation_template()`
- `ui_file_written()`
- `open_file_if_needed()`
- `stop_if_null_or_empty()`
- `%||%`

This is the begining of a huge refactorisation...