### PR TITLE
Refactor set credentials() & add github_user argument

### DIFF
--- a/R/add_codeowners.R
+++ b/R/add_codeowners.R
@@ -6,6 +6,7 @@
 #' repository.
 #'
 #' @inheritParams add_citation
+#' @inheritParams set_credentials
 #'
 #' @return No return value.
 #'
@@ -19,6 +20,7 @@
 #' }
 
 add_codeowners <- function(
+  github_user = NULL,
   open = FALSE,
   overwrite = FALSE,
   quiet = FALSE
@@ -31,13 +33,15 @@ add_codeowners <- function(
 
   assert_file_not_exists_or_overwrite(rel_path, overwrite)
 
-  meta <- resolve_project_meta()
+  meta <- resolve_project_meta(
+    github_user = github_user
+  )
 
   if (should_create_file(full_path, overwrite)) {
     ensure_dir_exists(dirname(full_path))
 
     writeLines(
-      text = paste0("* @", get_github_user()),
+      text = paste0("* @", meta$github_user),
       con = full_path
     )
 

--- a/R/new_compendium.R
+++ b/R/new_compendium.R
@@ -175,6 +175,12 @@
 #'
 #'   For further information see [set_credentials()].
 #'
+#' @param github_user A character vector of length 1. The GitHub account name
+#'   of the maintainer of the package. If `NULL` (default) the function will
+#'   try to get this value by reading the `.Rprofile` file.
+#'
+#'   For further information see [set_credentials()].
+#'
 #' @param organisation A character vector of length 1. The GitHub organisation
 #'   to host the repository. If defined it will overwrite the GitHub pseudo.
 #'
@@ -232,6 +238,7 @@ new_compendium <- function(
   family = NULL,
   email = NULL,
   orcid = NULL,
+  github_user = NULL,
   organisation = NULL,
   renv = FALSE,
   dockerfile = FALSE,
@@ -251,7 +258,7 @@ new_compendium <- function(
 
   ## Check if git is well configured ----
 
-  github <- gh::gh_whoami()$"login"
+  github <- github_user %||% getOption("github_user")
 
   if (is.null(github)) {
     stop(

--- a/R/new_package.R
+++ b/R/new_package.R
@@ -165,8 +165,8 @@
 #'   For further information see [set_credentials()] and below the section
 #'   **Managing credentials**.
 #'
-#' @param github_user A character vector of length 1. The GitHub account name 
-#'   of the maintainer of the package. If `NULL` (default) the function will 
+#' @param github_user A character vector of length 1. The GitHub account name
+#'   of the maintainer of the package. If `NULL` (default) the function will
 #'   try to get this value by reading the `.Rprofile` file.
 #'
 #'   For further information see [set_credentials()] and below the section

--- a/R/new_package.R
+++ b/R/new_package.R
@@ -165,6 +165,13 @@
 #'   For further information see [set_credentials()] and below the section
 #'   **Managing credentials**.
 #'
+#' @param github_user A character vector of length 1. The GitHub account name 
+#'   of the maintainer of the package. If `NULL` (default) the function will 
+#'   try to get this value by reading the `.Rprofile` file.
+#'
+#'   For further information see [set_credentials()] and below the section
+#'   **Managing credentials**.
+#'
 #' @param organisation A character vector of length 1. The GitHub organisation
 #'   to host the repository. If defined it will overwrite the GitHub pseudo.
 #'
@@ -325,6 +332,7 @@ new_package <- function(
   family = NULL,
   email = NULL,
   orcid = NULL,
+  github_user = NULL,
   organisation = NULL,
   overwrite = FALSE,
   quiet = FALSE
@@ -346,7 +354,7 @@ new_package <- function(
 
   ## Check if git is well configured ----
 
-  github <- gh::gh_whoami()$"login"
+  github <- github_user %||% getOption("github_user")
 
   if (is.null(github)) {
     stop(

--- a/R/set_credentials.R
+++ b/R/set_credentials.R
@@ -1,28 +1,37 @@
-#' Store credentials to the .Rprofile
+#' Store user information in the .Rprofile
 #'
 #' @description
-#' This function is used to store user credentials in the `.Rprofile` file.
-#' Accepted credentials are listed below. This function is useful if user
-#' creates a lot of packages and/or research compendiums.
+#' This function is used to store user credentials (given and family names,
+#' email, ORCID, GitHub username, etc.) in the `.Rprofile` file.
+#' This function is useful to store user credentials once for all especially if
+#' the user creates a lot of R projects and/or if the user manually calls
+#' the `add_*()` functions.
 #'
-#' If the `.Rprofile` file does not exist this function will create it. Users
-#' need to paste the content of the clipboard to this file.
+#' This function will create the `.Rprofile` file if it does not exist. Then,
+#' the user needs to paste the content of the clipboard to this file (open by
+#' the function).
 #'
-#' @param given A character of length 1. The given name of the project
-#'   maintainer.
+#' @param given a `character` of length 1. The given name of the user
+#'   (considered as the maintainer and code owner of the project).
 #'
-#' @param family A character of length 1. The family name of the project
-#'   maintainer.
+#' @param family a `character` of length 1. The family name of the user
+#'   (considered as the maintainer and code owner of the project).
 #'
-#' @param email A character of length 1. The email address of the project
-#'   maintainer.
+#' @param email a `character` of length 1. The email address of the user
+#'   (considered as the maintainer and code owner of the project).
 #'
-#' @param orcid A character of length 1. The ORCID of the project maintainer.
+#' @param orcid a `character` of length 1. The ORCID of the user
+#'   (considered as the maintainer and code owner of the project).
 #'
-#' @param protocol A character of length 1. The GIT protocol used to
-#'   communicate with the GitHub remote. One of `'https'` or `'ssh'`. If you
-#'   don't know, keep the default value (i.e. `NULL`) and the protocol will be
-#'   `'https'`.
+#' @param github_user a `character` of length 1. The GitHub account name of the
+#'   user (considered as the maintainer and code owner of the project).
+#'
+#' @param protocol a `character` of length 1. The GIT protocol used to
+#'   communicate with GitHub. One of `'https'` or `'ssh'`. If you
+#'   don't know, keep the default value (i.e. `https`).
+#'
+#' @param open a `logical` value. If `TRUE` (default) the `.Rprofile` is opened
+#'   in the default text editor (recommended).
 #'
 #' @return No return value.
 #'
@@ -32,13 +41,15 @@
 #'
 #' @examples
 #' \dontrun{
-#' library(rcompendium)
-#'
-#'
-#' ## Define **ONCE FOR ALL** your credentials ----
-#'
-#' set_credentials("John", "Doe", "john.doe@domain.com",
-#'                 orcid = "9999-9999-9999-9999", protocol = "https")
+#' set_credentials(
+#'   given = "John",
+#'   family = "Doe",
+#'   email = "john.doe@domain.com",
+#'   orcid = "9999-9999-9999-9999",
+#'   github_user = "jdoe",
+#'   protocol = "https",
+#'   open = TRUE
+#' )
 #' }
 
 set_credentials <- function(
@@ -46,62 +57,25 @@ set_credentials <- function(
   family = NULL,
   email = NULL,
   orcid = NULL,
-  protocol = NULL
+  github_user = NULL,
+  protocol = "https",
+  open = TRUE
 ) {
   credentials <- as.list(match.call())[-1]
 
-  if (length(credentials)) {
-    r_prof <- "## RCompendium Credentials ----"
+  assert_valid_credentials(credentials)
+  assert_valid_git_protocol(credentials)
 
-    ## Check remote protocol ----
+  if (should_edit_r_profile(credentials)) {
+    credentials <- set_default_git_protocol(credentials)
 
-    protocol <- credentials["protocol"]$protocol
+    content <- create_r_profile_content(credentials)
 
-    if (!is.null(protocol)) {
-      stop_if_not_string(protocol)
-
-      if (!(protocol %in% c("https", "ssh"))) {
-        protocol <- NULL
-        stop("Argument 'protocol' must one among 'https' and 'ssh'.")
-      }
-
-      if (!is.null(protocol)) {
-        usethis_protocol <- getOption("usethis.protocol")
-
-        if (!is.null(usethis_protocol)) {
-          if (usethis_protocol == protocol) {
-            ui_oops("Protocol is already set to {ui_value(protocol)}")
-            protocol <- NULL
-          }
-        }
-      }
-    }
-
-    ## Check user credentials ----
-
-    credentials <- credentials[!(names(credentials) %in% "protocol")]
-
-    if (!is.null(credentials)) {
-      invisible(lapply(credentials, stop_if_not_string))
-
-      opts <- paste0(names(credentials), " = \"", unlist(credentials), "\"")
-      opts <- paste0(opts, collapse = ", ")
-
-      r_prof <- c(r_prof, paste0("options(", opts, ")", ""))
-    }
-
-    if (!is.null(protocol)) {
-      opts <- paste0("usethis.protocol = \"", protocol, "\"")
-      r_prof <- c(r_prof, paste0("options(", opts, ")", ""))
-    }
-
-    ## Re-write .Rprofile ----
-
-    ui_todo("Please paste the following lines to the {ui_value('.Rprofile')}:")
-    usethis::ui_code_block(r_prof)
+    ui_r_profile_content(content)
   }
 
-  usethis::edit_r_profile()
+  r_profile <- create_r_profile_if_needed()
+  open_file_if_needed(r_profile, open)
 
-  invisible(NULL)
+  invisible(r_profile)
 }

--- a/R/utils-checks.R
+++ b/R/utils-checks.R
@@ -70,39 +70,3 @@ stop_if_not_string <- function(...) {
 
   invisible(NULL)
 }
-
-
-#' **Check if arguments are numeric of length 1**
-#'
-#' @param ... one or several arguments
-#'
-#' @noRd
-
-stop_if_not_numeric <- function(...) {
-  args_values <- list(...)
-  names(args_values) <- as.list(match.call())[-1]
-
-  if (length(args_values)) {
-    is_numeric <- unlist(lapply(args_values, length))
-
-    if (any(is_numeric != 1)) {
-      stop(
-        "Argument '",
-        names(is_numeric[is_numeric != 1])[1],
-        "' must be a numeric of length 1."
-      )
-    }
-
-    is_numeric <- unlist(lapply(args_values, is.numeric))
-
-    if (any(!is_numeric)) {
-      stop(
-        "Argument '",
-        names(is_numeric[!is_numeric])[1],
-        "' must be a numeric of length 1."
-      )
-    }
-  }
-
-  invisible(NULL)
-}

--- a/R/utils-new.R
+++ b/R/utils-new.R
@@ -453,3 +453,146 @@ assert_valid_issue_template_name <- function(name) {
 
   invisible(NULL)
 }
+
+
+#' Assert git protocol
+#' @param meta a list of the user information.
+#' @noRd
+assert_valid_git_protocol <- function(meta) {
+  if (!is.null(meta$protocol)) {
+    if (!(meta$protocol %in% c("https", "ssh"))) {
+      stop(
+        "Argument 'protocol' must be equal to 'https' or 'ssh'",
+        call. = FALSE
+      )
+    }
+  }
+
+  invisible(NULL)
+}
+
+
+#' Assert user information
+#' @param meta a list of the user information.
+#' @noRd
+assert_valid_credentials <- function(meta) {
+  if (!is.null(meta)) {
+    if ("given" %in% names(meta)) {
+      given <- meta[["given"]]
+      stop_if_not_string(given)
+    }
+
+    if ("family" %in% names(meta)) {
+      family <- meta[["family"]]
+      stop_if_not_string(family)
+    }
+
+    if ("email" %in% names(meta)) {
+      email <- meta[["email"]]
+      stop_if_not_string(email)
+    }
+
+    if ("orcid" %in% names(meta)) {
+      orcid <- meta[["orcid"]]
+      stop_if_not_string(orcid)
+    }
+
+    if ("github_user" %in% names(meta)) {
+      github_user <- meta[["github_user"]]
+      stop_if_not_string(github_user)
+    }
+
+    if (!is.null(meta[["protocol"]])) {
+      if ("protocol" %in% names(meta)) {
+        protocol <- meta[["protocol"]]
+        stop_if_not_string(protocol)
+      }
+    }
+  }
+
+  invisible(NULL)
+}
+
+
+#' Set default git protocol to https and/or rename to 'usethis.protocol'
+#' @param meta a list of the user information.
+#' @noRd
+set_default_git_protocol <- function(meta) {
+  if (!("protocol" %in% names(meta))) {
+    meta[["usethis.protocol"]] <- "https"
+  } else {
+    meta[["usethis.protocol"]] <- meta[["protocol"]]
+    meta <- meta[!(names(meta) %in% "protocol")]
+  }
+
+  meta
+}
+
+
+#' Return TRUE if the user provide information
+#' @param meta a list of the user information.
+#' @noRd
+should_edit_r_profile <- function(meta) {
+  if (length(meta) > 0) {
+    return(TRUE)
+  } else {
+    return(FALSE)
+  }
+}
+
+
+#' Create information message to edit the user .Rprofile
+#' @param meta a list of the user information.
+#' @noRd
+create_r_profile_content <- function(meta) {
+  r_prof <- "## rcompendium credentials ----"
+
+  opts <- paste0("\n  ", names(meta), " = \"", unlist(meta), "\"")
+  opts <- paste0(opts, collapse = ", ")
+
+  c(r_prof, paste0("options(", opts, "\n)", ""))
+}
+
+
+#' Display information message to edit the user .Rprofile
+#' @param content a character of length 1.
+#' @noRd
+ui_r_profile_content <- function(content) {
+  cli::cli_alert_warning(
+    paste0(
+      "Please copy and paste the following lines to the ",
+      "{.file {build_r_profile_path()}}:"
+    )
+  )
+
+  cat("\n")
+  cli::cli_code(format(content))
+
+  invisible(NULL)
+}
+
+
+#' Build the path to the user .Rprofile
+#' @noRd
+build_r_profile_path <- function() {
+  custom_r_profile_path <- Sys.getenv("R_PROFILE_USER")
+  if (custom_r_profile_path != "") {
+    r_profile_path <- custom_r_profile_path
+  } else {
+    r_profile_path <- file.path(fs::path_home_r(), ".Rprofile")
+  }
+
+  r_profile_path
+}
+
+
+#' Create the user .Rprofile (if required) and return the path
+#' @noRd
+create_r_profile_if_needed <- function() {
+  r_profile_path <- build_r_profile_path()
+  if (!file.exists((r_profile_path))) {
+    invisible(file.create(r_profile_path))
+  }
+
+  invisible(r_profile_path)
+}

--- a/R/utils-new.R
+++ b/R/utils-new.R
@@ -1,13 +1,8 @@
-#' Get project full path
-#' @noRd
-get_proj_path <- function() usethis::proj_get()
-
-
 #' Build an absolute path
 #' @param ... one or several folder/file names
 #' @noRd
 build_full_path <- function(...) {
-  file.path(get_proj_path(), ...)
+  file.path(path_proj(), ...)
 }
 
 

--- a/R/utils-new.R
+++ b/R/utils-new.R
@@ -45,6 +45,8 @@ resolve_project_meta <- function(...) {
   family <- args$family %||% getOption("family")
   email <- args$email %||% getOption("email")
   orcid <- args$orcid %||% getOption("orcid")
+  github_user <- args$github_user %||% getOption("github_user")
+  github_account <- args$organisation %||% github_user
 
   list(
     given = given,
@@ -57,8 +59,8 @@ resolve_project_meta <- function(...) {
     license = get_project_license_name(),
     license_url = get_project_license_url(),
 
-    github_user = get_github_user(),
-    github_account = resolve_github_account(args$organisation),
+    github_user = github_user,
+    github_account = github_account,
     git_branch = get_git_branch_name(),
 
     r_version = paste(
@@ -72,36 +74,6 @@ resolve_project_meta <- function(...) {
     year = format(Sys.Date(), "%Y"),
     date = format(Sys.time(), "%Y/%m/%d")
   )
-}
-
-
-#' Retrieve GitHub account of the repo
-#' @param organisation a character of length 1 (optional). The name of the GH
-#'   organisation. If `NULL` (default), the user account is used.
-#' @noRd
-resolve_github_account <- function(organisation = NULL) {
-  if (!is.null(organisation)) {
-    stop_if_not_string(organisation)
-    return(organisation)
-  }
-
-  get_github_user()
-}
-
-
-#' Retrieve GitHub account name
-#' @noRd
-get_github_user <- function() {
-  github <- gh::gh_whoami()$"login"
-
-  if (is.null(github)) {
-    stop(
-      "Unable to find GitHub username. Please run ",
-      "`?gh::gh_whoami` for more information."
-    )
-  }
-
-  github
 }
 
 

--- a/man/add_citation.Rd
+++ b/man/add_citation.Rd
@@ -14,11 +14,11 @@ add_citation(
 )
 }
 \arguments{
-\item{given}{A character of length 1. The given name of the project
-maintainer.}
+\item{given}{a \code{character} of length 1. The given name of the user
+(considered as the maintainer and code owner of the project).}
 
-\item{family}{A character of length 1. The family name of the project
-maintainer.}
+\item{family}{a \code{character} of length 1. The family name of the user
+(considered as the maintainer and code owner of the project).}
 
 \item{organisation}{A character of length 1. The name of the GitHub
 organisation to host the package. If \code{NULL} (default) the GitHub account

--- a/man/add_code_of_conduct.Rd
+++ b/man/add_code_of_conduct.Rd
@@ -12,8 +12,8 @@ add_code_of_conduct(
 )
 }
 \arguments{
-\item{email}{A character of length 1. The email address of the project
-maintainer.}
+\item{email}{a \code{character} of length 1. The email address of the user
+(considered as the maintainer and code owner of the project).}
 
 \item{open}{A logical value. If \code{TRUE} (default) the file is opened in the
 editor.}

--- a/man/add_codeowners.Rd
+++ b/man/add_codeowners.Rd
@@ -4,9 +4,17 @@
 \alias{add_codeowners}
 \title{Create a CODEOWNERS file}
 \usage{
-add_codeowners(open = FALSE, overwrite = FALSE, quiet = FALSE)
+add_codeowners(
+  github_user = NULL,
+  open = FALSE,
+  overwrite = FALSE,
+  quiet = FALSE
+)
 }
 \arguments{
+\item{github_user}{a \code{character} of length 1. The GitHub account name of the
+user (considered as the maintainer and code owner of the project).}
+
 \item{open}{A logical value. If \code{TRUE} (default) the file is opened in the
 editor.}
 

--- a/man/add_contributing.Rd
+++ b/man/add_contributing.Rd
@@ -13,8 +13,8 @@ add_contributing(
 )
 }
 \arguments{
-\item{email}{A character of length 1. The email address of the project
-maintainer.}
+\item{email}{a \code{character} of length 1. The email address of the user
+(considered as the maintainer and code owner of the project).}
 
 \item{organisation}{A character of length 1. The name of the GitHub
 organisation to host the package. If \code{NULL} (default) the GitHub account

--- a/man/add_description.Rd
+++ b/man/add_description.Rd
@@ -16,16 +16,17 @@ add_description(
 )
 }
 \arguments{
-\item{given}{A character of length 1. The given name of the project
-maintainer.}
+\item{given}{a \code{character} of length 1. The given name of the user
+(considered as the maintainer and code owner of the project).}
 
-\item{family}{A character of length 1. The family name of the project
-maintainer.}
+\item{family}{a \code{character} of length 1. The family name of the user
+(considered as the maintainer and code owner of the project).}
 
-\item{email}{A character of length 1. The email address of the project
-maintainer.}
+\item{email}{a \code{character} of length 1. The email address of the user
+(considered as the maintainer and code owner of the project).}
 
-\item{orcid}{A character of length 1. The ORCID of the project maintainer.}
+\item{orcid}{a \code{character} of length 1. The ORCID of the user
+(considered as the maintainer and code owner of the project).}
 
 \item{organisation}{A character of length 1. The name of the GitHub
 organisation to host the package. If \code{NULL} (default) the GitHub account

--- a/man/add_dockerfile.Rd
+++ b/man/add_dockerfile.Rd
@@ -14,14 +14,14 @@ add_dockerfile(
 )
 }
 \arguments{
-\item{given}{A character of length 1. The given name of the project
-maintainer.}
+\item{given}{a \code{character} of length 1. The given name of the user
+(considered as the maintainer and code owner of the project).}
 
-\item{family}{A character of length 1. The family name of the project
-maintainer.}
+\item{family}{a \code{character} of length 1. The family name of the user
+(considered as the maintainer and code owner of the project).}
 
-\item{email}{A character of length 1. The email address of the project
-maintainer.}
+\item{email}{a \code{character} of length 1. The email address of the user
+(considered as the maintainer and code owner of the project).}
 
 \item{open}{A logical value. If \code{TRUE} (default) the \code{Dockerfile} is opened
 in the editor.}

--- a/man/add_license.Rd
+++ b/man/add_license.Rd
@@ -10,11 +10,11 @@ add_license(license = NULL, given = NULL, family = NULL, quiet = FALSE)
 \item{license}{A character of length 1. The license name.
 Run \code{\link[=get_licenses]{get_licenses()}}) to select an appropriate one.}
 
-\item{given}{A character of length 1. The given name of the project
-maintainer.}
+\item{given}{a \code{character} of length 1. The given name of the user
+(considered as the maintainer and code owner of the project).}
 
-\item{family}{A character of length 1. The family name of the project
-maintainer.}
+\item{family}{a \code{character} of length 1. The family name of the user
+(considered as the maintainer and code owner of the project).}
 
 \item{quiet}{A logical value. If \code{TRUE} messages are deleted. Default is
 \code{FALSE}.}

--- a/man/add_makefile.Rd
+++ b/man/add_makefile.Rd
@@ -14,14 +14,14 @@ add_makefile(
 )
 }
 \arguments{
-\item{given}{A character of length 1. The given name of the project
-maintainer.}
+\item{given}{a \code{character} of length 1. The given name of the user
+(considered as the maintainer and code owner of the project).}
 
-\item{family}{A character of length 1. The family name of the project
-maintainer.}
+\item{family}{a \code{character} of length 1. The family name of the user
+(considered as the maintainer and code owner of the project).}
 
-\item{email}{A character of length 1. The email address of the project
-maintainer.}
+\item{email}{a \code{character} of length 1. The email address of the user
+(considered as the maintainer and code owner of the project).}
 
 \item{open}{A logical value. If \code{TRUE} (default) the file is opened in the
 editor.}

--- a/man/add_readme_rmd.Rd
+++ b/man/add_readme_rmd.Rd
@@ -19,11 +19,11 @@ add_readme_rmd(
 \code{README.Rmd} specific to an R package will be created. If \code{compendium} a
 GitHub \code{README.Rmd} specific to a research compendium will be created.}
 
-\item{given}{A character of length 1. The given name of the project
-maintainer.}
+\item{given}{a \code{character} of length 1. The given name of the user
+(considered as the maintainer and code owner of the project).}
 
-\item{family}{A character of length 1. The family name of the project
-maintainer.}
+\item{family}{a \code{character} of length 1. The family name of the user
+(considered as the maintainer and code owner of the project).}
 
 \item{organisation}{A character of length 1. The name of the GitHub
 organisation to host the package. If \code{NULL} (default) the GitHub account

--- a/man/new_compendium.Rd
+++ b/man/new_compendium.Rd
@@ -27,6 +27,7 @@ new_compendium(
   family = NULL,
   email = NULL,
   orcid = NULL,
+  github_user = NULL,
   organisation = NULL,
   renv = FALSE,
   dockerfile = FALSE,
@@ -162,6 +163,12 @@ For further information see \code{\link[=set_credentials]{set_credentials()}}.}
 \item{orcid}{A character vector of length 1. The ORCID of the maintainer of
 the package. If \code{NULL} (default) the function will try to get this value
 by reading the \code{.Rprofile} file.
+
+For further information see \code{\link[=set_credentials]{set_credentials()}}.}
+
+\item{github_user}{A character vector of length 1. The GitHub account name
+of the maintainer of the package. If \code{NULL} (default) the function will
+try to get this value by reading the \code{.Rprofile} file.
 
 For further information see \code{\link[=set_credentials]{set_credentials()}}.}
 

--- a/man/new_package.Rd
+++ b/man/new_package.Rd
@@ -26,6 +26,7 @@ new_package(
   family = NULL,
   email = NULL,
   orcid = NULL,
+  github_user = NULL,
   organisation = NULL,
   overwrite = FALSE,
   quiet = FALSE
@@ -160,6 +161,13 @@ For further information see \code{\link[=set_credentials]{set_credentials()}} an
 \item{orcid}{A character vector of length 1. The ORCID of the maintainer of
 the package. If \code{NULL} (default) the function will try to get this value
 by reading the \code{.Rprofile} file.
+
+For further information see \code{\link[=set_credentials]{set_credentials()}} and below the section
+\strong{Managing credentials}.}
+
+\item{github_user}{A character vector of length 1. The GitHub account name
+of the maintainer of the package. If \code{NULL} (default) the function will
+try to get this value by reading the \code{.Rprofile} file.
 
 For further information see \code{\link[=set_credentials]{set_credentials()}} and below the section
 \strong{Managing credentials}.}

--- a/man/set_credentials.Rd
+++ b/man/set_credentials.Rd
@@ -2,53 +2,66 @@
 % Please edit documentation in R/set_credentials.R
 \name{set_credentials}
 \alias{set_credentials}
-\title{Store credentials to the .Rprofile}
+\title{Store user information in the .Rprofile}
 \usage{
 set_credentials(
   given = NULL,
   family = NULL,
   email = NULL,
   orcid = NULL,
-  protocol = NULL
+  github_user = NULL,
+  protocol = "https",
+  open = TRUE
 )
 }
 \arguments{
-\item{given}{A character of length 1. The given name of the project
-maintainer.}
+\item{given}{a \code{character} of length 1. The given name of the user
+(considered as the maintainer and code owner of the project).}
 
-\item{family}{A character of length 1. The family name of the project
-maintainer.}
+\item{family}{a \code{character} of length 1. The family name of the user
+(considered as the maintainer and code owner of the project).}
 
-\item{email}{A character of length 1. The email address of the project
-maintainer.}
+\item{email}{a \code{character} of length 1. The email address of the user
+(considered as the maintainer and code owner of the project).}
 
-\item{orcid}{A character of length 1. The ORCID of the project maintainer.}
+\item{orcid}{a \code{character} of length 1. The ORCID of the user
+(considered as the maintainer and code owner of the project).}
 
-\item{protocol}{A character of length 1. The GIT protocol used to
-communicate with the GitHub remote. One of \code{'https'} or \code{'ssh'}. If you
-don't know, keep the default value (i.e. \code{NULL}) and the protocol will be
-\code{'https'}.}
+\item{github_user}{a \code{character} of length 1. The GitHub account name of the
+user (considered as the maintainer and code owner of the project).}
+
+\item{protocol}{a \code{character} of length 1. The GIT protocol used to
+communicate with GitHub. One of \code{'https'} or \code{'ssh'}. If you
+don't know, keep the default value (i.e. \code{https}).}
+
+\item{open}{a \code{logical} value. If \code{TRUE} (default) the \code{.Rprofile} is opened
+in the default text editor (recommended).}
 }
 \value{
 No return value.
 }
 \description{
-This function is used to store user credentials in the \code{.Rprofile} file.
-Accepted credentials are listed below. This function is useful if user
-creates a lot of packages and/or research compendiums.
+This function is used to store user credentials (given and family names,
+email, ORCID, GitHub username, etc.) in the \code{.Rprofile} file.
+This function is useful to store user credentials once for all especially if
+the user creates a lot of R projects and/or if the user manually calls
+the \verb{add_*()} functions.
 
-If the \code{.Rprofile} file does not exist this function will create it. Users
-need to paste the content of the clipboard to this file.
+This function will create the \code{.Rprofile} file if it does not exist. Then,
+the user needs to paste the content of the clipboard to this file (open by
+the function).
 }
 \examples{
 \dontrun{
-library(rcompendium)
-
-
-## Define **ONCE FOR ALL** your credentials ----
-
-set_credentials("John", "Doe", "john.doe@domain.com",
-                orcid = "9999-9999-9999-9999", protocol = "https")
+set_credentials(
+  given = "John",
+  family = "Doe",
+  email = "john.doe@domain.com",
+  orcid = "9999-9999-9999-9999",
+  github_user = "jdoe",
+  protocol = "https",
+  open = TRUE
+)
 }
 }
 \seealso{

--- a/tests/testthat/test-assert_file_not_exists_or_overwrite.R
+++ b/tests/testthat/test-assert_file_not_exists_or_overwrite.R
@@ -1,0 +1,46 @@
+## assert_file_not_exists_or_overwrite() ----
+
+test_that("assert_file_not_exists_or_overwrite() errors", {
+  with_local_project({
+    invisible(file.create(".here"))
+    invisible(file.create(build_full_path("README")))
+
+    expect_error(
+      assert_file_not_exists_or_overwrite("README", overwrite = FALSE),
+      paste0(
+        "The file 'README' already exists. ",
+        "To replace it, please use `overwrite = TRUE`."
+      ),
+      fixed = TRUE
+    )
+  })
+})
+
+test_that("assert_file_not_exists_or_overwrite() works - overwrite is TRUE", {
+  with_local_project({
+    invisible(file.create(".here"))
+    invisible(file.create(build_full_path("README")))
+
+    expect_silent(
+      assert_file_not_exists_or_overwrite("README", overwrite = TRUE)
+    )
+
+    expect_null(
+      x <- assert_file_not_exists_or_overwrite("README", overwrite = TRUE)
+    )
+  })
+})
+
+test_that("assert_file_not_exists_or_overwrite() works - file not exists", {
+  with_local_project({
+    invisible(file.create(".here"))
+
+    expect_silent(
+      assert_file_not_exists_or_overwrite("DESCRIPTION", overwrite = FALSE)
+    )
+
+    expect_null(
+      x <- assert_file_not_exists_or_overwrite("DESCRIPTION", overwrite = FALSE)
+    )
+  })
+})

--- a/tests/testthat/test-assert_valid_credentials.R
+++ b/tests/testthat/test-assert_valid_credentials.R
@@ -206,7 +206,7 @@ test_that("assert_valid_credentials() works", {
     github_user = "jdoe",
     protocol = "ssh"
   )
-  
+
   expect_silent(assert_valid_credentials(meta))
   expect_null(x <- assert_valid_credentials(meta))
 })

--- a/tests/testthat/test-assert_valid_credentials.R
+++ b/tests/testthat/test-assert_valid_credentials.R
@@ -1,0 +1,212 @@
+## assert_valid_credentials() ----
+
+test_that("assert_valid_credentials() errors", {
+  expect_error(
+    assert_valid_credentials(list(given = 12)),
+    "Argument 'given' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(given = TRUE)),
+    "Argument 'given' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(given = letters)),
+    "Argument 'given' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(family = 12)),
+    "Argument 'family' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(family = TRUE)),
+    "Argument 'family' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(family = letters)),
+    "Argument 'family' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(given = "John", family = letters)),
+    "Argument 'family' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(email = 12)),
+    "Argument 'email' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(email = TRUE)),
+    "Argument 'email' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(email = letters)),
+    "Argument 'email' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(given = "John", email = letters)),
+    "Argument 'email' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(orcid = 12)),
+    "Argument 'orcid' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(orcid = TRUE)),
+    "Argument 'orcid' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(orcid = letters)),
+    "Argument 'orcid' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(given = "John", orcid = letters)),
+    "Argument 'orcid' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(github_user = 12)),
+    "Argument 'github_user' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(github_user = TRUE)),
+    "Argument 'github_user' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(github_user = letters)),
+    "Argument 'github_user' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(given = "John", github_user = letters)),
+    "Argument 'github_user' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(protocol = 12)),
+    "Argument 'protocol' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(protocol = TRUE)),
+    "Argument 'protocol' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(protocol = letters)),
+    "Argument 'protocol' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_credentials(list(given = "John", protocol = letters)),
+    "Argument 'protocol' must be a character of length 1.",
+    fixed = TRUE
+  )
+})
+
+test_that("assert_valid_credentials() works", {
+  meta <- list()
+
+  expect_silent(assert_valid_credentials(meta))
+  expect_null(x <- assert_valid_credentials(meta))
+
+  meta <- list(given = "John")
+  expect_silent(assert_valid_credentials(meta))
+  expect_null(x <- assert_valid_credentials(meta))
+
+  meta <- list(family = "Doe")
+  expect_silent(assert_valid_credentials(meta))
+  expect_null(x <- assert_valid_credentials(meta))
+
+  meta <- list(given = "John", family = "Doe")
+  expect_silent(assert_valid_credentials(meta))
+  expect_null(x <- assert_valid_credentials(meta))
+
+  meta <- list(email = "john.doe@mail.com")
+  expect_silent(assert_valid_credentials(meta))
+  expect_null(x <- assert_valid_credentials(meta))
+
+  meta <- list(email = "john.doe@mail.com", family = "Doe")
+  expect_silent(assert_valid_credentials(meta))
+  expect_null(x <- assert_valid_credentials(meta))
+
+  meta <- list(orcid = "0000-0000-0000-0000")
+  expect_silent(assert_valid_credentials(meta))
+  expect_null(x <- assert_valid_credentials(meta))
+
+  meta <- list(given = "John", orcid = "0000-0000-0000-0000")
+  expect_silent(assert_valid_credentials(meta))
+  expect_null(x <- assert_valid_credentials(meta))
+
+  meta <- list(github_user = "jdoe")
+  expect_silent(assert_valid_credentials(meta))
+  expect_null(x <- assert_valid_credentials(meta))
+
+  meta <- list(github_user = "jdoe", family = "Doe")
+  expect_silent(assert_valid_credentials(meta))
+  expect_null(x <- assert_valid_credentials(meta))
+
+  meta <- list(protocol = "https")
+  expect_silent(assert_valid_credentials(meta))
+  expect_null(x <- assert_valid_credentials(meta))
+
+  meta <- list(protocol = "https", family = "Doe")
+  expect_silent(assert_valid_credentials(meta))
+  expect_null(x <- assert_valid_credentials(meta))
+
+  meta <- list(protocol = "ssh")
+  expect_silent(assert_valid_credentials(meta))
+  expect_null(x <- assert_valid_credentials(meta))
+
+  meta <- list(protocol = "ssh", family = "Doe")
+  expect_silent(assert_valid_credentials(meta))
+  expect_null(x <- assert_valid_credentials(meta))
+
+  meta <- list(
+    given = "John",
+    family = "Doe",
+    email = "john.doe@mail.com",
+    orcid = "0000-0000-0000-0000",
+    github_user = "jdoe",
+    protocol = "ssh"
+  )
+  
+  expect_silent(assert_valid_credentials(meta))
+  expect_null(x <- assert_valid_credentials(meta))
+})

--- a/tests/testthat/test-assert_valid_git_protocol.R
+++ b/tests/testthat/test-assert_valid_git_protocol.R
@@ -1,0 +1,27 @@
+## assert_valid_git_protocol() ----
+
+test_that("assert_valid_git_protocol() errors", {
+  expect_error(
+    assert_valid_git_protocol(list(protocol = "ftp")),
+    "Argument 'protocol' must be equal to 'https' or 'ssh'",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_git_protocol(list(protocol = "SSH")),
+    "Argument 'protocol' must be equal to 'https' or 'ssh'",
+    fixed = TRUE
+  )
+
+  expect_error(
+    assert_valid_git_protocol(list(protocol = "")),
+    "Argument 'protocol' must be equal to 'https' or 'ssh'",
+    fixed = TRUE
+  )
+})
+
+test_that("assert_valid_git_protocol() works", {
+  expect_silent(assert_valid_git_protocol(list(protocol = "https")))
+  expect_silent(assert_valid_git_protocol(list(protocol = "ssh")))
+  expect_null(x <- assert_valid_git_protocol(list(protocol = "ssh")))
+})

--- a/tests/testthat/test-build_full_path.R
+++ b/tests/testthat/test-build_full_path.R
@@ -1,0 +1,20 @@
+## build_full_path() ----
+
+test_that("build_full_path() works", {
+  with_local_project({
+    invisible(file.create(".here"))
+    path <- file.path("README")
+
+    output <- build_full_path(path)
+    expect_true(inherits(output, "character"))
+    expect_equal(length(output), 1L)
+    expect_equal(output, file.path(path_proj(), path))
+
+    path <- file.path("subdir", "README")
+
+    output <- build_full_path(path)
+    expect_true(inherits(output, "character"))
+    expect_equal(length(output), 1L)
+    expect_equal(output, file.path(path_proj(), path))
+  })
+})

--- a/tests/testthat/test-build_r_profile_path.R
+++ b/tests/testthat/test-build_r_profile_path.R
@@ -1,0 +1,27 @@
+## build_r_profile_path() ----
+
+test_that("build_r_profile_path() works - Use ~/.Rprofile", {
+  with_local_project({
+    withr::local_envvar(
+      list(R_PROFILE_USER = "")
+    )
+
+    expect_equal(
+      build_r_profile_path(),
+      file.path(fs::path_home_r(), ".Rprofile")
+    )
+  })
+})
+
+test_that("build_r_profile_path() works - Use R_PROFILE_USER", {
+  with_local_project({
+    withr::local_envvar(
+      list(R_PROFILE_USER = "/home/user/.Rprofile")
+    )
+
+    expect_equal(
+      build_r_profile_path(),
+      "/home/user/.Rprofile"
+    )
+  })
+})

--- a/tests/testthat/test-build_rel_path.R
+++ b/tests/testthat/test-build_rel_path.R
@@ -1,0 +1,17 @@
+## build_rel_path() ----
+
+test_that("build_rel_path() works", {
+  path <- file.path("README")
+
+  output <- build_rel_path(path)
+  expect_true(inherits(output, "character"))
+  expect_equal(length(output), 1L)
+  expect_equal(output, path)
+
+  path <- file.path("subdir", "README")
+
+  output <- build_rel_path(path)
+  expect_true(inherits(output, "character"))
+  expect_equal(length(output), 1L)
+  expect_equal(output, path)
+})

--- a/tests/testthat/test-create_r_profile_content.R
+++ b/tests/testthat/test-create_r_profile_content.R
@@ -10,13 +10,11 @@ test_that("create_r_profile_content() works", {
 
   expect_equal(
     output[1],
-    "## rcompendium credentials ----",
-    fixed = TRUE
+    "## rcompendium credentials ----"
   )
 
   expect_equal(
     output[2],
-    "options(\n  given = \"John\", \n  family = \"Doe\"\n)",
-    fixed = TRUE
+    "options(\n  given = \"John\", \n  family = \"Doe\"\n)"
   )
 })

--- a/tests/testthat/test-create_r_profile_content.R
+++ b/tests/testthat/test-create_r_profile_content.R
@@ -1,0 +1,22 @@
+## create_r_profile_content() ----
+
+test_that("create_r_profile_content() works", {
+  meta <- list(given = "John", family = "Doe")
+
+  output <- create_r_profile_content(meta)
+
+  expect_true(inherits(output, "character"))
+  expect_equal(length(output), 2L)
+
+  expect_equal(
+    output[1],
+    "## rcompendium credentials ----",
+    fixed = TRUE
+  )
+
+  expect_equal(
+    output[2],
+    "options(\n  given = \"John\", \n  family = \"Doe\"\n)",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-create_r_profile_if_needed.R
+++ b/tests/testthat/test-create_r_profile_if_needed.R
@@ -1,0 +1,33 @@
+## create_r_profile_if_needed() ----
+
+test_that("create_r_profile_if_needed() works - .Rprofile is missing", {
+  with_local_project({
+    r_profile <- file.path(getwd(), ".Rprofile")
+
+    withr::local_envvar(
+      list(R_PROFILE_USER = r_profile)
+    )
+
+    output <- create_r_profile_if_needed()
+
+    expect_equal(output, r_profile)
+    expect_true(file.exists(r_profile))
+  })
+})
+
+test_that("create_r_profile_if_needed() works - .Rprofile exists", {
+  with_local_project({
+    r_profile <- file.path(getwd(), ".Rprofile")
+
+    withr::local_envvar(
+      list(R_PROFILE_USER = r_profile)
+    )
+
+    invisible(file.create(r_profile))
+
+    output <- create_r_profile_if_needed()
+
+    expect_equal(output, r_profile)
+    expect_true(file.exists(r_profile))
+  })
+})

--- a/tests/testthat/test-ensure_dir_exists.R
+++ b/tests/testthat/test-ensure_dir_exists.R
@@ -1,0 +1,43 @@
+## ensure_dir_exists() ----
+
+test_that("ensure_dir_exists() works - dir not exists", {
+  with_local_project({
+    invisible(file.create(".here"))
+
+    path <- build_full_path(file.path("R"))
+
+    expect_silent(ensure_dir_exists(path))
+    expect_null(x <- ensure_dir_exists(path))
+
+    expect_true(dir.exists(path))
+
+    path <- build_full_path(file.path("tests", "testthat"))
+
+    expect_silent(ensure_dir_exists(path))
+    expect_null(x <- ensure_dir_exists(path))
+
+    expect_true(dir.exists(path))
+  })
+})
+
+test_that("ensure_dir_exists() works - dir exists", {
+  with_local_project({
+    invisible(file.create(".here"))
+
+    path <- build_full_path(file.path("man"))
+    dir.create(path, recursive = TRUE, showWarnings = FALSE)
+
+    expect_silent(ensure_dir_exists(path))
+    expect_null(x <- ensure_dir_exists(path))
+
+    expect_true(dir.exists(path))
+
+    path <- build_full_path(file.path("man", "figures"))
+    dir.create(path, recursive = TRUE, showWarnings = FALSE)
+
+    expect_silent(ensure_dir_exists(path))
+    expect_null(x <- ensure_dir_exists(path))
+
+    expect_true(dir.exists(path))
+  })
+})

--- a/tests/testthat/test-populate_template.R
+++ b/tests/testthat/test-populate_template.R
@@ -1,0 +1,111 @@
+## populate_template() ----
+
+test_that("populate_template() works - no metadata", {
+  with_local_project({
+    invisible(file.create(".here"))
+
+    path <- build_full_path("LICENSE")
+
+    content <- c("YEAR: {{year}}", "COPYRIGHT HOLDER: {{given}} {{family}}")
+    writeLines(text = content, con = path)
+
+    meta <- list()
+
+    expect_silent(populate_template(path, meta))
+    expect_null(x <- populate_template(path, meta))
+
+    output <- readLines(path)
+
+    expect_equal(output[1], "YEAR: {{year}}")
+    expect_equal(output[2], "COPYRIGHT HOLDER: {{given}} {{family}}")
+  })
+})
+
+test_that("populate_template() works - unused metadata", {
+  with_local_project({
+    invisible(file.create(".here"))
+
+    path <- build_full_path("LICENSE")
+
+    content <- c("YEAR: {{year}}", "COPYRIGHT HOLDER: {{given}} {{family}}")
+    writeLines(text = content, con = path)
+
+    meta <- list(orcid = "0000-0000-0000-0000", github_user = "jdoe")
+
+    expect_silent(populate_template(path, meta))
+    expect_null(x <- populate_template(path, meta))
+
+    output <- readLines(path)
+
+    expect_equal(output[1], "YEAR: {{year}}")
+    expect_equal(output[2], "COPYRIGHT HOLDER: {{given}} {{family}}")
+  })
+})
+
+test_that("populate_template() works - one used metadata", {
+  with_local_project({
+    invisible(file.create(".here"))
+
+    path <- build_full_path("LICENSE")
+
+    content <- c("YEAR: {{year}}", "COPYRIGHT HOLDER: {{given}} {{family}}")
+    writeLines(text = content, con = path)
+
+    meta <- list(given = "John", github_user = "jdoe")
+
+    expect_silent(populate_template(path, meta))
+    expect_null(x <- populate_template(path, meta))
+
+    output <- readLines(path)
+
+    expect_equal(output[1], "YEAR: {{year}}")
+    expect_equal(output[2], "COPYRIGHT HOLDER: John {{family}}")
+  })
+})
+
+test_that("populate_template() works - one used metadata & one is NULL", {
+  with_local_project({
+    invisible(file.create(".here"))
+
+    path <- build_full_path("LICENSE")
+
+    content <- c("YEAR: {{year}}", "COPYRIGHT HOLDER: {{given}} {{family}}")
+    writeLines(text = content, con = path)
+
+    meta <- list(given = "John", family = NULL, github_user = "jdoe")
+
+    expect_silent(populate_template(path, meta))
+    expect_null(x <- populate_template(path, meta))
+
+    output <- readLines(path)
+
+    expect_equal(output[1], "YEAR: {{year}}")
+    expect_equal(output[2], "COPYRIGHT HOLDER: John {{family}}")
+  })
+})
+
+test_that("populate_template() works - many used metadata", {
+  with_local_project({
+    invisible(file.create(".here"))
+
+    path <- build_full_path("LICENSE")
+
+    content <- c("YEAR: {{year}}", "COPYRIGHT HOLDER: {{given}} {{family}}")
+    writeLines(text = content, con = path)
+
+    meta <- list(
+      given = "John",
+      family = "Doe",
+      year = "2026",
+      github_user = "jdoe"
+    )
+
+    expect_silent(populate_template(path, meta))
+    expect_null(x <- populate_template(path, meta))
+
+    output <- readLines(path)
+
+    expect_equal(output[1], "YEAR: 2026")
+    expect_equal(output[2], "COPYRIGHT HOLDER: John Doe")
+  })
+})

--- a/tests/testthat/test-set_default_git_protocol.R
+++ b/tests/testthat/test-set_default_git_protocol.R
@@ -1,0 +1,28 @@
+## set_default_git_protocol() ----
+
+test_that("set_default_git_protocol() works - Protocol set to https", {
+  output <- set_default_git_protocol(list(protocol = "https"))
+
+  expect_true(inherits(output, "list"))
+  expect_true("usethis.protocol" %in% names(output))
+  expect_equal(length(output), 1L)
+  expect_equal(output[["usethis.protocol"]], "https")
+})
+
+test_that("set_default_git_protocol() works - Protocol is missing", {
+  output <- set_default_git_protocol(list(given = "John"))
+
+  expect_true(inherits(output, "list"))
+  expect_true("usethis.protocol" %in% names(output))
+  expect_equal(length(output), 2L)
+  expect_equal(output[["usethis.protocol"]], "https")
+})
+
+test_that("set_default_git_protocol() works - Protocol set to ssh", {
+  output <- set_default_git_protocol(list(protocol = "ssh"))
+
+  expect_true(inherits(output, "list"))
+  expect_true("usethis.protocol" %in% names(output))
+  expect_equal(length(output), 1L)
+  expect_equal(output[["usethis.protocol"]], "ssh")
+})

--- a/tests/testthat/test-should_create_file.R
+++ b/tests/testthat/test-should_create_file.R
@@ -1,0 +1,30 @@
+## should_create_file() ----
+
+test_that("should_create_file() works - file not exists", {
+  with_local_project({
+    invisible(file.create(".here"))
+
+    expect_true(
+      should_create_file("README", overwrite = FALSE)
+    )
+
+    expect_true(
+      should_create_file("README", overwrite = TRUE)
+    )
+  })
+})
+
+test_that("should_create_file() works - file exists", {
+  with_local_project({
+    invisible(file.create(".here"))
+    invisible(file.create("README"))
+
+    expect_false(
+      should_create_file("README", overwrite = FALSE)
+    )
+
+    expect_true(
+      should_create_file("README", overwrite = TRUE)
+    )
+  })
+})

--- a/tests/testthat/test-should_edit_r_profile.R
+++ b/tests/testthat/test-should_edit_r_profile.R
@@ -1,0 +1,20 @@
+## should_edit_r_profile() ----
+
+test_that("should_edit_r_profile() works - Return FALSE", {
+  expect_false(
+    should_edit_r_profile(list())
+  )
+
+  expect_false(
+    should_edit_r_profile(NULL)
+  )
+})
+
+test_that("should_edit_r_profile() works - Return TRUE", {
+  expect_true(
+    should_edit_r_profile(list(given = "John"))
+  )
+  expect_true(
+    should_edit_r_profile(list(given = "John", family = "Doe"))
+  )
+})

--- a/tests/testthat/test-stop_if_not_logical.R
+++ b/tests/testthat/test-stop_if_not_logical.R
@@ -1,0 +1,102 @@
+## stop_if_not_logical() ----
+
+test_that("stop_if_not_logical() errors", {
+  quiet <- 12
+  overwrite <- TRUE
+
+  expect_error(
+    stop_if_not_logical(quiet),
+    "Argument 'quiet' must be a logical of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    stop_if_not_logical(quiet, overwrite),
+    "Argument 'quiet' must be a logical of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    stop_if_not_logical(overwrite, quiet),
+    "Argument 'quiet' must be a logical of length 1.",
+    fixed = TRUE
+  )
+
+  quiet <- "string"
+  overwrite <- TRUE
+
+  expect_error(
+    stop_if_not_logical(quiet),
+    "Argument 'quiet' must be a logical of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    stop_if_not_logical(quiet, overwrite),
+    "Argument 'quiet' must be a logical of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    stop_if_not_logical(overwrite, quiet),
+    "Argument 'quiet' must be a logical of length 1.",
+    fixed = TRUE
+  )
+
+  quiet <- NULL
+  overwrite <- TRUE
+
+  expect_error(
+    stop_if_not_logical(quiet),
+    "Argument 'quiet' must be a logical of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    stop_if_not_logical(quiet, overwrite),
+    "Argument 'quiet' must be a logical of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    stop_if_not_logical(overwrite, quiet),
+    "Argument 'quiet' must be a logical of length 1.",
+    fixed = TRUE
+  )
+
+  quiet <- c(TRUE, TRUE)
+  overwrite <- TRUE
+
+  expect_error(
+    stop_if_not_logical(quiet),
+    "Argument 'quiet' must be a logical of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    stop_if_not_logical(quiet, overwrite),
+    "Argument 'quiet' must be a logical of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    stop_if_not_logical(overwrite, quiet),
+    "Argument 'quiet' must be a logical of length 1.",
+    fixed = TRUE
+  )
+})
+
+test_that("stop_if_not_logical() works", {
+  quiet <- TRUE
+  overwrite <- FALSE
+  open <- FALSE
+
+  expect_silent(stop_if_not_logical())
+  expect_null(x <- stop_if_not_logical())
+
+  expect_silent(stop_if_not_logical(quiet))
+  expect_null(x <- stop_if_not_logical(quiet))
+
+  expect_silent(stop_if_not_logical(quiet, overwrite, open))
+  expect_null(x <- stop_if_not_logical(quiet, open, overwrite))
+})

--- a/tests/testthat/test-stop_if_not_string.R
+++ b/tests/testthat/test-stop_if_not_string.R
@@ -1,0 +1,102 @@
+## stop_if_not_string() ----
+
+test_that("stop_if_not_string() errors", {
+  given <- 12
+  family <- "Doe"
+
+  expect_error(
+    stop_if_not_string(given),
+    "Argument 'given' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    stop_if_not_string(given, family),
+    "Argument 'given' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    stop_if_not_string(family, given),
+    "Argument 'given' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  given <- TRUE
+  family <- "Doe"
+
+  expect_error(
+    stop_if_not_string(given),
+    "Argument 'given' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    stop_if_not_string(given, family),
+    "Argument 'given' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    stop_if_not_string(family, given),
+    "Argument 'given' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  given <- NULL
+  family <- "Doe"
+
+  expect_error(
+    stop_if_not_string(given),
+    "Argument 'given' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    stop_if_not_string(given, family),
+    "Argument 'given' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    stop_if_not_string(family, given),
+    "Argument 'given' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  given <- c("Marie", "Jeanne")
+  family <- "Doe"
+
+  expect_error(
+    stop_if_not_string(given),
+    "Argument 'given' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    stop_if_not_string(given, family),
+    "Argument 'given' must be a character of length 1.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    stop_if_not_string(family, given),
+    "Argument 'given' must be a character of length 1.",
+    fixed = TRUE
+  )
+})
+
+test_that("stop_if_not_string() works", {
+  given <- "John"
+  family <- "Doe"
+  orcid <- "0000-0000-0000-0000"
+
+  expect_silent(stop_if_not_string())
+  expect_null(x <- stop_if_not_string())
+
+  expect_silent(stop_if_not_string(given))
+  expect_null(x <- stop_if_not_string(given))
+
+  expect_silent(stop_if_not_string(given, family, orcid))
+  expect_null(x <- stop_if_not_string(given, orcid, family))
+})

--- a/tests/testthat/test-stop_if_null_or_empty.R
+++ b/tests/testthat/test-stop_if_null_or_empty.R
@@ -1,0 +1,31 @@
+## stop_if_null_or_empty() ----
+
+test_that("stop_if_null_or_empty() errors", {
+  expect_error(
+    stop_if_null_or_empty(NULL, "given"),
+    "Argument 'given' is required but is NULL or empty.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    stop_if_null_or_empty("", "given"),
+    "Argument 'given' is required but is NULL or empty.",
+    fixed = TRUE
+  )
+
+  expect_error(
+    stop_if_null_or_empty(character(0), "given"),
+    "Argument 'given' is required but is NULL or empty.",
+    fixed = TRUE
+  )
+})
+
+test_that("stop_if_null_or_empty() works", {
+  expect_silent(
+    stop_if_null_or_empty("John", "given")
+  )
+
+  expect_null(
+    x <- stop_if_null_or_empty("John", "given")
+  )
+})

--- a/tests/testthat/test-ui_file_not_written.R
+++ b/tests/testthat/test-ui_file_not_written.R
@@ -1,0 +1,22 @@
+## ui_file_not_written() ----
+
+test_that("ui_file_not_written() works - verbose", {
+  with_local_project({
+    path <- file.path(".github", "dependabot.yaml")
+
+    expect_message(ui_file_not_written(path))
+    expect_null(x <- ui_file_not_written(path))
+
+    expect_message(ui_file_not_written(path, quiet = FALSE))
+    expect_null(x <- ui_file_not_written(path, quiet = FALSE))
+  })
+})
+
+test_that("ui_file_not_written() works - quiet", {
+  with_local_project({
+    path <- file.path(".github", "dependabot.yaml")
+
+    expect_silent(ui_file_not_written(path, quiet = TRUE))
+    expect_null(x <- ui_file_not_written(path, quiet = TRUE))
+  })
+})

--- a/tests/testthat/test-ui_file_written.R
+++ b/tests/testthat/test-ui_file_written.R
@@ -1,0 +1,22 @@
+## ui_file_written() ----
+
+test_that("ui_file_written() works - verbose", {
+  with_local_project({
+    path <- file.path(".github", "dependabot.yaml")
+
+    expect_message(ui_file_written(path))
+    expect_null(x <- ui_file_written(path))
+
+    expect_message(ui_file_written(path, quiet = FALSE))
+    expect_null(x <- ui_file_written(path, quiet = FALSE))
+  })
+})
+
+test_that("ui_file_written() works - quiet", {
+  with_local_project({
+    path <- file.path(".github", "dependabot.yaml")
+
+    expect_silent(ui_file_written(path, quiet = TRUE))
+    expect_null(x <- ui_file_written(path, quiet = TRUE))
+  })
+})

--- a/tests/testthat/test-ui_r_profile_content.R
+++ b/tests/testthat/test-ui_r_profile_content.R
@@ -1,0 +1,15 @@
+## ui_r_profile_content() ----
+
+test_that("ui_r_profile_content() works", {
+  with_local_project({
+    r_profile <- file.path(getwd(), ".Rprofile")
+
+    withr::local_envvar(
+      list(R_PROFILE_USER = r_profile)
+    )
+
+    expect_message(
+      ui_r_profile_content("This is a message")
+    )
+  })
+})


### PR DESCRIPTION
This PR fixes #103 and #122, #123 & #124 and introduces a new argument, `github_user`.

Also, it refactors `set_credentials()` and implements a new set of helpers, especially to handle the user `.Rprofile`