### PR TITLE
Initialize project if required

### DIFF
--- a/R/create_new_compendium.R
+++ b/R/create_new_compendium.R
@@ -250,11 +250,7 @@ create_new_compendium <- function(
   overwrite = FALSE,
   quiet = FALSE
 ) {
-  ## If not RStudio ----
-
-  if (!rstudioapi::isAvailable()) {
-    if (!file.exists(".here")) file.create(".here")
-  }
+  initialize_project(quiet)
 
   ## Check for inceptions ----
 

--- a/R/create_new_package.R
+++ b/R/create_new_package.R
@@ -342,11 +342,7 @@ create_new_package <- function(
   overwrite = FALSE,
   quiet = FALSE
 ) {
-  ## If not RStudio ----
-
-  if (!rstudioapi::isAvailable()) {
-    if (!file.exists(".here")) file.create(".here")
-  }
+  initialize_project(quiet)
 
   ## Check for inceptions ----
 

--- a/R/utils-new.R
+++ b/R/utils-new.R
@@ -211,7 +211,11 @@ stop_if_not_project <- function() {
     paste0(basename(getwd()), ".Rproj"),
     ".here",
     "renv.lock",
-    ".vscode/settings.json"
+    ".vscode/settings.json",
+    "_pkgdown.yaml",
+    "_pkgdown.yml",
+    "_quarto.yaml",
+    "_quarto.yml"
   )
 
   if (all(!file.exists(markers))) {
@@ -562,4 +566,54 @@ create_r_profile_if_needed <- function() {
   }
 
   invisible(r_profile_path)
+}
+
+
+initialize_project <- function(quiet = FALSE) {
+  ui_title("Initializing project", quiet)
+
+  markers <- c(
+    "DESCRIPTION",
+    ".git",
+    paste0(basename(getwd()), ".Rproj"),
+    ".here",
+    "renv.lock",
+    ".vscode/settings.json",
+    "_pkgdown.yaml",
+    "_pkgdown.yml",
+    "_quarto.yaml",
+    "_quarto.yml"
+  )
+
+  if (all(!file.exists(markers))) {
+    content <- list.files(getwd(), all.files = TRUE, no.. = TRUE)
+    if (length(content) == 0) {
+      invisible(file.create(".here"))
+      ui_file_written(".here", quiet)
+    } else {
+      stop(
+        paste0(
+          "The path '",
+          getwd(),
+          "' is not empty and does not appear to be an R project."
+        )
+      )
+    }
+  }
+
+  ui_project_initialized(getwd(), quiet)
+  invisible(NULL)
+}
+
+
+#' Inform user that the project has been initiliazed
+#' @param path a character of length of 1. The absolute path of the project.
+#' @param quiet a logical of length 1.
+#' @noRd
+ui_project_initialized <- function(path, quiet = FALSE) {
+  if (!quiet) {
+    cli::cli_alert_success("Setting active project to {.val {path}}")
+  }
+
+  invisible(NULL)
 }

--- a/R/utils-new.R
+++ b/R/utils-new.R
@@ -205,20 +205,7 @@ stop_if_null_or_empty <- function(value, name) {
 #' Error if the current working directory is not a project/package
 #' @noRd
 stop_if_not_project <- function() {
-  markers <- c(
-    "DESCRIPTION",
-    ".git",
-    paste0(basename(getwd()), ".Rproj"),
-    ".here",
-    "renv.lock",
-    ".vscode/settings.json",
-    "_pkgdown.yaml",
-    "_pkgdown.yml",
-    "_quarto.yaml",
-    "_quarto.yml"
-  )
-
-  if (all(!file.exists(markers))) {
+  if (!assert_project_file_detected()) {
     stop(paste0(
       "The path '",
       getwd(),
@@ -569,23 +556,13 @@ create_r_profile_if_needed <- function() {
 }
 
 
+#' Initialize project (create .here if require)
+#' @param quiet a logical of length 1.
+#' @noRd
 initialize_project <- function(quiet = FALSE) {
   ui_title("Initializing project", quiet)
 
-  markers <- c(
-    "DESCRIPTION",
-    ".git",
-    paste0(basename(getwd()), ".Rproj"),
-    ".here",
-    "renv.lock",
-    ".vscode/settings.json",
-    "_pkgdown.yaml",
-    "_pkgdown.yml",
-    "_quarto.yaml",
-    "_quarto.yml"
-  )
-
-  if (all(!file.exists(markers))) {
+  if (!assert_project_file_detected()) {
     content <- list.files(getwd(), all.files = TRUE, no.. = TRUE)
     if (length(content) == 0) {
       invisible(file.create(".here"))
@@ -616,4 +593,28 @@ ui_project_initialized <- function(path, quiet = FALSE) {
   }
 
   invisible(NULL)
+}
+
+
+#' Assert if current directory is an R project
+#' @noRd
+assert_project_file_detected <- function() {
+  markers <- c(
+    "DESCRIPTION",
+    ".git",
+    paste0(basename(getwd()), ".Rproj"),
+    ".here",
+    "renv.lock",
+    ".vscode/settings.json",
+    "_pkgdown.yaml",
+    "_pkgdown.yml",
+    "_quarto.yaml",
+    "_quarto.yml"
+  )
+
+  if (all(!file.exists(markers))) {
+    return(FALSE)
+  } else {
+    return(TRUE)
+  }
 }

--- a/R/utils-new.R
+++ b/R/utils-new.R
@@ -19,7 +19,7 @@ build_rel_path <- function(...) {
 #' @param overwrite a logical of length 1.
 #' @noRd
 assert_file_not_exists_or_overwrite <- function(path, overwrite) {
-  if (file.exists(build_full_path(path)) && !overwrite) {
+  if (file.exists(path) && !overwrite) {
     stop(
       paste0(
         "The file '",

--- a/R/utils-sys.R
+++ b/R/utils-sys.R
@@ -130,11 +130,13 @@ proj_in_proj <- function() {
 #'
 #' @noRd
 
-ui_title <- function(texte) {
-  cli::cat_line()
-  cat(cli::symbol$radio_on, cli::style_bold(cli::style_underline(texte)))
-  cli::cat_line()
-  cli::cat_line()
+ui_title <- function(texte, quiet = FALSE) {
+  if (!quiet) {
+    cli::cat_line()
+    cat(cli::symbol$radio_on, cli::style_bold(cli::style_underline(texte)))
+    cli::cat_line()
+    cli::cat_line()
+  }
 
   invisible(NULL)
 }

--- a/tests/testthat/test-add_description.R
+++ b/tests/testthat/test-add_description.R
@@ -2,7 +2,7 @@
 
 test_that("add_description() errors - Logical args", {
   with_local_project({
-    file.create(".here")
+    initialize_project(quiet = TRUE)
 
     expect_error(add_description(open = 0))
     expect_error(add_description(quiet = 0))
@@ -21,7 +21,7 @@ test_that("add_description() errors - Logical args", {
 
 test_that("add_description() errors - set_credentials() not used", {
   with_local_project({
-    file.create(".here")
+    initialize_project(quiet = TRUE)
 
     withr::local_options(
       list(

--- a/tests/testthat/test-assert_file_not_exists_or_overwrite.R
+++ b/tests/testthat/test-assert_file_not_exists_or_overwrite.R
@@ -2,8 +2,9 @@
 
 test_that("assert_file_not_exists_or_overwrite() errors", {
   with_local_project({
-    invisible(file.create(".here"))
-    invisible(file.create(build_full_path("README")))
+    initialize_project(quiet = TRUE)
+
+    invisible(file.create("README"))
 
     expect_error(
       assert_file_not_exists_or_overwrite("README", overwrite = FALSE),
@@ -18,8 +19,17 @@ test_that("assert_file_not_exists_or_overwrite() errors", {
 
 test_that("assert_file_not_exists_or_overwrite() works - overwrite is TRUE", {
   with_local_project({
-    invisible(file.create(".here"))
-    invisible(file.create(build_full_path("README")))
+    initialize_project(quiet = TRUE)
+
+    expect_silent(
+      assert_file_not_exists_or_overwrite("README", overwrite = TRUE)
+    )
+
+    expect_null(
+      x <- assert_file_not_exists_or_overwrite("README", overwrite = TRUE)
+    )
+
+    invisible(file.create("README"))
 
     expect_silent(
       assert_file_not_exists_or_overwrite("README", overwrite = TRUE)
@@ -33,14 +43,14 @@ test_that("assert_file_not_exists_or_overwrite() works - overwrite is TRUE", {
 
 test_that("assert_file_not_exists_or_overwrite() works - file not exists", {
   with_local_project({
-    invisible(file.create(".here"))
+    initialize_project(quiet = TRUE)
 
     expect_silent(
-      assert_file_not_exists_or_overwrite("DESCRIPTION", overwrite = FALSE)
+      assert_file_not_exists_or_overwrite("README", overwrite = FALSE)
     )
 
     expect_null(
-      x <- assert_file_not_exists_or_overwrite("DESCRIPTION", overwrite = FALSE)
+      x <- assert_file_not_exists_or_overwrite("README", overwrite = FALSE)
     )
   })
 })

--- a/tests/testthat/test-assert_project_file_detected.R
+++ b/tests/testthat/test-assert_project_file_detected.R
@@ -1,0 +1,60 @@
+## assert_project_file_detected() ----
+
+test_that("assert_project_file_detected() works - Not a project", {
+  with_local_project({
+    expect_false(assert_project_file_detected())
+  })
+})
+
+test_that("assert_project_file_detected() works - Is a project", {
+  with_local_project({
+    file.create(".here")
+    expect_true(assert_project_file_detected())
+  })
+
+  with_local_project({
+    file.create("DESCRIPTION")
+    expect_true(assert_project_file_detected())
+  })
+
+  with_local_project({
+    dir.create(".git")
+    expect_true(assert_project_file_detected())
+  })
+
+  with_local_project({
+    dir.create(".vscode")
+    file.create(file.path(".vscode", "settings.json"))
+    expect_true(assert_project_file_detected())
+  })
+
+  with_local_project({
+    file.create("renv.lock")
+    expect_true(assert_project_file_detected())
+  })
+
+  with_local_project({
+    file.create("pkgtest.Rproj")
+    expect_true(assert_project_file_detected())
+  })
+
+  with_local_project({
+    file.create("_pkgdown.yaml")
+    expect_true(assert_project_file_detected())
+  })
+
+  with_local_project({
+    file.create("_pkgdown.yml")
+    expect_true(assert_project_file_detected())
+  })
+
+  with_local_project({
+    file.create("_quarto.yaml")
+    expect_true(assert_project_file_detected())
+  })
+
+  with_local_project({
+    file.create("_quarto.yml")
+    expect_true(assert_project_file_detected())
+  })
+})

--- a/tests/testthat/test-build_full_path.R
+++ b/tests/testthat/test-build_full_path.R
@@ -2,17 +2,18 @@
 
 test_that("build_full_path() works", {
   with_local_project({
-    invisible(file.create(".here"))
-    path <- file.path("README")
+    initialize_project(quiet = TRUE)
 
+    path <- file.path("README")
     output <- build_full_path(path)
+
     expect_true(inherits(output, "character"))
     expect_equal(length(output), 1L)
     expect_equal(output, file.path(path_proj(), path))
 
     path <- file.path("subdir", "README")
-
     output <- build_full_path(path)
+
     expect_true(inherits(output, "character"))
     expect_equal(length(output), 1L)
     expect_equal(output, file.path(path_proj(), path))

--- a/tests/testthat/test-ensure_dir_exists.R
+++ b/tests/testthat/test-ensure_dir_exists.R
@@ -2,7 +2,7 @@
 
 test_that("ensure_dir_exists() works - dir not exists", {
   with_local_project({
-    invisible(file.create(".here"))
+    initialize_project(quiet = TRUE)
 
     path <- build_full_path(file.path("R"))
 
@@ -22,7 +22,7 @@ test_that("ensure_dir_exists() works - dir not exists", {
 
 test_that("ensure_dir_exists() works - dir exists", {
   with_local_project({
-    invisible(file.create(".here"))
+    initialize_project(quiet = TRUE)
 
     path <- build_full_path(file.path("man"))
     dir.create(path, recursive = TRUE, showWarnings = FALSE)

--- a/tests/testthat/test-initialize_project.R
+++ b/tests/testthat/test-initialize_project.R
@@ -1,0 +1,150 @@
+## initialize_project() ----
+
+test_that("initialize_project() errors", {
+  with_local_project({
+    path <- file.path(getwd(), "README")
+    invisible(file.create(path))
+
+    expect_error(
+      initialize_project(quiet = TRUE),
+      paste0(
+        "The path '",
+        getwd(),
+        "' is not empty and does not appear to be an R project."
+      ),
+      fixed = TRUE
+    )
+  })
+})
+
+test_that("initialize_project() works - no additional files", {
+  with_local_project({
+    expect_no_message(initialize_project(quiet = TRUE))
+    expect_null(x <- initialize_project(quiet = TRUE))
+    expect_true(file.exists(".here"))
+  })
+
+  with_local_project({
+    file.create(".here")
+    expect_no_message(initialize_project(quiet = TRUE))
+  })
+
+  with_local_project({
+    file.create("DESCRIPTION")
+    expect_no_message(initialize_project(quiet = TRUE))
+  })
+
+  with_local_project({
+    dir.create(".git")
+    expect_no_message(initialize_project(quiet = TRUE))
+  })
+
+  with_local_project({
+    dir.create(".vscode")
+    file.create(file.path(".vscode", "settings.json"))
+    expect_no_message(initialize_project(quiet = TRUE))
+  })
+
+  with_local_project({
+    file.create("renv.lock")
+    expect_no_message(initialize_project(quiet = TRUE))
+  })
+
+  with_local_project({
+    file.create("pkgtest.Rproj")
+    expect_no_message(initialize_project(quiet = TRUE))
+  })
+
+  with_local_project({
+    file.create("_pkgdown.yaml")
+    expect_no_message(initialize_project(quiet = TRUE))
+  })
+
+  with_local_project({
+    file.create("_pkgdown.yml")
+    expect_no_message(initialize_project(quiet = TRUE))
+  })
+
+  with_local_project({
+    file.create("_quarto.yaml")
+    expect_no_message(initialize_project(quiet = TRUE))
+  })
+
+  with_local_project({
+    file.create("_quarto.yml")
+    expect_no_message(initialize_project(quiet = TRUE))
+  })
+})
+
+test_that("initialize_project() works - with additional files", {
+  with_local_project({
+    file.create(".here")
+    path <- file.path(getwd(), "README")
+    invisible(file.create(path))
+    expect_no_message(initialize_project(quiet = TRUE))
+  })
+
+  with_local_project({
+    file.create("DESCRIPTION")
+    path <- file.path(getwd(), "README")
+    invisible(file.create(path))
+    expect_no_message(initialize_project(quiet = TRUE))
+  })
+
+  with_local_project({
+    dir.create(".git")
+    path <- file.path(getwd(), "README")
+    invisible(file.create(path))
+    expect_no_message(initialize_project(quiet = TRUE))
+  })
+
+  with_local_project({
+    dir.create(".vscode")
+    path <- file.path(getwd(), "README")
+    invisible(file.create(path))
+    file.create(file.path(".vscode", "settings.json"))
+    expect_no_message(initialize_project(quiet = TRUE))
+  })
+
+  with_local_project({
+    file.create("renv.lock")
+    path <- file.path(getwd(), "README")
+    invisible(file.create(path))
+    expect_no_message(initialize_project(quiet = TRUE))
+  })
+
+  with_local_project({
+    file.create("pkgtest.Rproj")
+    path <- file.path(getwd(), "README")
+    invisible(file.create(path))
+    expect_no_message(initialize_project(quiet = TRUE))
+  })
+
+  with_local_project({
+    file.create("_pkgdown.yaml")
+    path <- file.path(getwd(), "README")
+    invisible(file.create(path))
+    expect_no_message(initialize_project(quiet = TRUE))
+  })
+
+  with_local_project({
+    file.create("_pkgdown.yml")
+    path <- file.path(getwd(), "README")
+    invisible(file.create(path))
+    expect_no_message(initialize_project(quiet = TRUE))
+  })
+
+  with_local_project({
+    file.create("_quarto.yaml")
+    path <- file.path(getwd(), "README")
+    invisible(file.create(path))
+    expect_no_message(initialize_project(quiet = TRUE))
+  })
+
+  with_local_project({
+    file.create("_quarto.yml")
+    path <- file.path(getwd(), "README")
+    invisible(file.create(path))
+    expect_no_message(initialize_project(quiet = TRUE))
+  })
+})

--- a/tests/testthat/test-populate_template.R
+++ b/tests/testthat/test-populate_template.R
@@ -2,7 +2,7 @@
 
 test_that("populate_template() works - no metadata", {
   with_local_project({
-    invisible(file.create(".here"))
+    initialize_project(quiet = TRUE)
 
     path <- build_full_path("LICENSE")
 
@@ -23,7 +23,7 @@ test_that("populate_template() works - no metadata", {
 
 test_that("populate_template() works - unused metadata", {
   with_local_project({
-    invisible(file.create(".here"))
+    initialize_project(quiet = TRUE)
 
     path <- build_full_path("LICENSE")
 
@@ -44,7 +44,7 @@ test_that("populate_template() works - unused metadata", {
 
 test_that("populate_template() works - one used metadata", {
   with_local_project({
-    invisible(file.create(".here"))
+    initialize_project(quiet = TRUE)
 
     path <- build_full_path("LICENSE")
 
@@ -65,7 +65,7 @@ test_that("populate_template() works - one used metadata", {
 
 test_that("populate_template() works - one used metadata & one is NULL", {
   with_local_project({
-    invisible(file.create(".here"))
+    initialize_project(quiet = TRUE)
 
     path <- build_full_path("LICENSE")
 
@@ -86,7 +86,7 @@ test_that("populate_template() works - one used metadata & one is NULL", {
 
 test_that("populate_template() works - many used metadata", {
   with_local_project({
-    invisible(file.create(".here"))
+    initialize_project(quiet = TRUE)
 
     path <- build_full_path("LICENSE")
 

--- a/tests/testthat/test-should_create_file.R
+++ b/tests/testthat/test-should_create_file.R
@@ -2,7 +2,7 @@
 
 test_that("should_create_file() works - file not exists", {
   with_local_project({
-    invisible(file.create(".here"))
+    initialize_project(quiet = TRUE)
 
     expect_true(
       should_create_file("README", overwrite = FALSE)
@@ -16,7 +16,8 @@ test_that("should_create_file() works - file not exists", {
 
 test_that("should_create_file() works - file exists", {
   with_local_project({
-    invisible(file.create(".here"))
+    initialize_project(quiet = TRUE)
+
     invisible(file.create("README"))
 
     expect_false(

--- a/tests/testthat/test-stop_if_not_project.R
+++ b/tests/testthat/test-stop_if_not_project.R
@@ -45,4 +45,24 @@ test_that("stop_if_not_project() works", {
     file.create("pkgtest.Rproj")
     expect_silent(stop_if_not_project())
   })
+
+  with_local_project({
+    file.create("_pkgdown.yaml")
+    expect_silent(stop_if_not_project())
+  })
+
+  with_local_project({
+    file.create("_pkgdown.yml")
+    expect_silent(stop_if_not_project())
+  })
+
+  with_local_project({
+    file.create("_quarto.yaml")
+    expect_silent(stop_if_not_project())
+  })
+
+  with_local_project({
+    file.create("_quarto.yml")
+    expect_silent(stop_if_not_project())
+  })
 })

--- a/tests/testthat/test-stop_if_not_project.R
+++ b/tests/testthat/test-stop_if_not_project.R
@@ -16,7 +16,8 @@ test_that("stop_if_not_project() errors", {
 
 test_that("stop_if_not_project() works", {
   with_local_project({
-    file.create(".here")
+    initialize_project(quiet = TRUE)
+    
     expect_silent(stop_if_not_project())
   })
 

--- a/tests/testthat/test-stop_if_not_project.R
+++ b/tests/testthat/test-stop_if_not_project.R
@@ -17,7 +17,7 @@ test_that("stop_if_not_project() errors", {
 test_that("stop_if_not_project() works", {
   with_local_project({
     initialize_project(quiet = TRUE)
-    
+
     expect_silent(stop_if_not_project())
   })
 

--- a/tests/testthat/test-ui_file_not_written.R
+++ b/tests/testthat/test-ui_file_not_written.R
@@ -4,11 +4,14 @@ test_that("ui_file_not_written() works - verbose", {
   with_local_project({
     path <- file.path(".github", "dependabot.yaml")
 
-    expect_message(ui_file_not_written(path))
-    expect_null(x <- ui_file_not_written(path))
+    expect_no_message(suppressMessages(ui_file_not_written(path)))
+    expect_null(x <- suppressMessages(ui_file_not_written(path)))
 
-    expect_message(ui_file_not_written(path, quiet = FALSE))
-    expect_null(x <- ui_file_not_written(path, quiet = FALSE))
+    expect_no_message(suppressMessages(ui_file_not_written(
+      path,
+      quiet = FALSE
+    )))
+    expect_null(x <- suppressMessages(ui_file_not_written(path, quiet = FALSE)))
   })
 })
 

--- a/tests/testthat/test-ui_file_written.R
+++ b/tests/testthat/test-ui_file_written.R
@@ -4,11 +4,11 @@ test_that("ui_file_written() works - verbose", {
   with_local_project({
     path <- file.path(".github", "dependabot.yaml")
 
-    expect_message(ui_file_written(path))
-    expect_null(x <- ui_file_written(path))
+    expect_no_message(suppressMessages(ui_file_written(path)))
+    expect_null(x <- suppressMessages(ui_file_written(path)))
 
-    expect_message(ui_file_written(path, quiet = FALSE))
-    expect_null(x <- ui_file_written(path, quiet = FALSE))
+    expect_no_message(suppressMessages(ui_file_written(path, quiet = FALSE)))
+    expect_null(x <- suppressMessages(ui_file_written(path, quiet = FALSE)))
   })
 })
 

--- a/tests/testthat/test-ui_r_profile_content.R
+++ b/tests/testthat/test-ui_r_profile_content.R
@@ -8,8 +8,12 @@ test_that("ui_r_profile_content() works", {
       list(R_PROFILE_USER = r_profile)
     )
 
-    expect_message(
-      ui_r_profile_content("This is a message")
+    expect_no_message(suppressMessages(ui_r_profile_content(
+      "This is a message"
+    )))
+
+    expect_null(
+      x <- suppressMessages(ui_r_profile_content("This is a message"))
     )
   })
 })


### PR DESCRIPTION
This PR fixes #92 and #98 and introduces `initialize_project()` function that will create an `.here` file if required.

Also introduces `assert_project_file_detected()` that returns a boolean and refactors `stop_if_not_project()`. 