### PR TITLE
Fix badge end location condition check

### DIFF
--- a/R/utils-io.R
+++ b/R/utils-io.R
@@ -90,7 +90,7 @@ add_badge <- function(badge, pattern) {
   badge_start <- grep("<!-- badges: start -->", read_me)
   badge_end <- grep("<!-- badges: end -->", read_me)
 
-  if (!length(badge_start) || !length(badge_start)) {
+  if (!length(badge_start) || !length(badge_end)) {
     stop(
       "Unable to parse badges location in 'README.Rmd' file.\n",
       "Did you remove the tag '<!-- badges: start -->' and/or ",


### PR DESCRIPTION
This pull request fixes a small bug in the `add_badge` function in `R/utils-io.R`. The condition that checks for missing badge tags in the README was corrected to check both the start and end tags, ensuring the function properly detects when either is missing.