### PR TITLE
Apply `Jarl` fixes

### DIFF
--- a/R/add_badge.R
+++ b/R/add_badge.R
@@ -49,7 +49,7 @@ add_badge <- function(badge, pattern) {
       collapse = "\n"
     )
     badges <- unlist(strsplit(badges, "\n"))
-    badges <- badges[!(badges == "")]
+    badges <- badges[badges != ""]
   }
 
   ## Replace/Add badge ----

--- a/R/add_renv.R
+++ b/R/add_renv.R
@@ -67,14 +67,14 @@ add_renv <- function(quiet = FALSE) {
 
     if (!is.null(deps)) {
       deps <- unlist(strsplit(deps, "\n\\s+|,|,\\s+"))
-      deps <- deps[!(deps == "")]
+      deps <- deps[deps != ""]
       deps_to_add <- deps_to_add[!(deps_to_add %in% deps)]
     }
 
     if (length(deps_to_add)) {
       if (!is.null(descr$"Imports")) {
         deps_in_imports <- unlist(strsplit(descr$"Imports", "\n\\s+|,|,\\s+"))
-        deps_in_imports <- deps_in_imports[!(deps_in_imports == "")]
+        deps_in_imports <- deps_in_imports[deps_in_imports != ""]
       } else {
         deps_in_imports <- character(0)
       }

--- a/R/add_vignette.R
+++ b/R/add_vignette.R
@@ -164,14 +164,14 @@ add_vignette <- function(
 
   if (!is.null(deps)) {
     deps <- unlist(strsplit(deps, "\n\\s+|,|,\\s+"))
-    deps <- deps[!(deps == "")]
+    deps <- deps[deps != ""]
     deps_to_add <- deps_to_add[!(deps_to_add %in% deps)]
   }
 
   if (length(deps_to_add)) {
     if (!is.null(descr$"Suggests")) {
       deps_in_suggests <- unlist(strsplit(descr$"Suggests", "\n\\s+|,|,\\s+"))
-      deps_in_suggests <- deps_in_suggests[!(deps_in_suggests == "")]
+      deps_in_suggests <- deps_in_suggests[deps_in_suggests != ""]
     } else {
       deps_in_suggests <- character(0)
     }

--- a/R/get_all_dependencies.R
+++ b/R/get_all_dependencies.R
@@ -43,7 +43,7 @@ get_all_dependencies <- function(pkg = NULL) {
 
     if (!is.null(direct_deps)) {
       direct_deps <- unlist(strsplit(direct_deps, "\n\\s+|,|,\\s+"))
-      direct_deps <- direct_deps[!(direct_deps == "")]
+      direct_deps <- direct_deps[direct_deps != ""]
 
       pkg <- direct_deps
     } else {

--- a/R/get_minimal_r_version.R
+++ b/R/get_minimal_r_version.R
@@ -38,7 +38,7 @@ get_minimal_r_version <- function(pkg = NULL) {
     )
 
     direct_deps <- unlist(strsplit(direct_deps, "\n\\s+|,|,\\s+"))
-    direct_deps <- direct_deps[!(direct_deps == "")]
+    direct_deps <- direct_deps[direct_deps != ""]
 
     pkg <- direct_deps
   } else {

--- a/R/utils-deps.R
+++ b/R/utils-deps.R
@@ -664,7 +664,7 @@ get_deps_in_depends <- function() {
       deps <- deps[-r_version]
     }
 
-    deps <- deps[!(deps == "")]
+    deps <- deps[deps != ""]
     return(gsub("\\s{0,}\\(.*\\)", "", deps))
   } else {
     return(NULL)
@@ -684,7 +684,7 @@ get_deps_in_imports <- function() {
   if (!is.null(descr$"Imports")) {
     deps <- unlist(strsplit(descr$"Imports", "\n\\s+|,|,\\s+"))
 
-    return(deps[!(deps == "")])
+    return(deps[deps != ""])
   } else {
     return(NULL)
   }
@@ -703,7 +703,7 @@ get_deps_in_suggests <- function() {
   if (!is.null(descr$"Suggests")) {
     deps <- unlist(strsplit(descr$"Suggests", "\n\\s+|,|,\\s+"))
 
-    return(deps[!(deps == "")])
+    return(deps[deps != ""])
   } else {
     return(NULL)
   }

--- a/R/utils-meta.R
+++ b/R/utils-meta.R
@@ -5,14 +5,14 @@
 resolve_project_meta <- function(..., include = .DEFAULT_BLOCKS) {
   valid_blocks <- .DEFAULT_BLOCKS
 
-  if (any(is.na(include))) {
+  if (anyNA(include)) {
     stop(
       "Argument 'include' cannot contain NA values.",
       call. = FALSE
     )
   }
 
-  if (any(!(include %in% valid_blocks))) {
+  if (!all((include %in% valid_blocks))) {
     stop(
       sprintf(
         "Invalid 'include' value(s): '%s'. Valid values are '%s'.",

--- a/tests/testthat/test-create_folder_if_needed.R
+++ b/tests/testthat/test-create_folder_if_needed.R
@@ -7,13 +7,15 @@ test_that("create_folder_if_needed() works - dir not exists", {
     path <- build_abs_path("R")
 
     expect_silent(create_folder_if_needed(path))
-    expect_null(x <- create_folder_if_needed(path))
+    x <- create_folder_if_needed(path)
+    expect_null(x)
     expect_true(dir.exists(path))
 
     path <- build_abs_path("tests", "testthat")
 
     expect_silent(create_folder_if_needed(path))
-    expect_null(x <- create_folder_if_needed(path))
+    x <- create_folder_if_needed(path)
+    expect_null(x)
     expect_true(dir.exists(path))
   })
 })
@@ -26,14 +28,16 @@ test_that("create_folder_if_needed() works - dir exists", {
     dir.create(path, recursive = TRUE, showWarnings = FALSE)
 
     expect_silent(create_folder_if_needed(path))
-    expect_null(x <- create_folder_if_needed(path))
+    x <- create_folder_if_needed(path)
+    expect_null(x)
     expect_true(dir.exists(path))
 
     path <- build_abs_path("man", "figures")
     dir.create(path, recursive = TRUE, showWarnings = FALSE)
 
     expect_silent(create_folder_if_needed(path))
-    expect_null(x <- create_folder_if_needed(path))
+    x <- create_folder_if_needed(path)
+    expect_null(x)
     expect_true(dir.exists(path))
   })
 })

--- a/tests/testthat/test-create_folder_if_needed.R
+++ b/tests/testthat/test-create_folder_if_needed.R
@@ -6,13 +6,17 @@ test_that("create_folder_if_needed() works - dir not exists", {
 
     path <- build_abs_path("R")
 
-    x <- expect_silent(create_folder_if_needed(path))
+    expect_silent({
+      x <- create_folder_if_needed(path)
+    })
     expect_null(x)
     expect_true(dir.exists(path))
 
     path <- build_abs_path("tests", "testthat")
 
-    x <- expect_silent(create_folder_if_needed(path))
+    expect_silent({
+      x <- create_folder_if_needed(path)
+    })
     expect_null(x)
     expect_true(dir.exists(path))
   })
@@ -25,14 +29,18 @@ test_that("create_folder_if_needed() works - dir exists", {
     path <- build_abs_path("man")
     dir.create(path, recursive = TRUE, showWarnings = FALSE)
 
-    x <- expect_silent(create_folder_if_needed(path))
+    expect_silent({
+      x <- create_folder_if_needed(path)
+    })
     expect_null(x)
     expect_true(dir.exists(path))
 
     path <- build_abs_path("man", "figures")
     dir.create(path, recursive = TRUE, showWarnings = FALSE)
 
-    x <- expect_silent(create_folder_if_needed(path))
+    expect_silent({
+      x <- create_folder_if_needed(path)
+    })
     expect_null(x)
     expect_true(dir.exists(path))
   })

--- a/tests/testthat/test-create_folder_if_needed.R
+++ b/tests/testthat/test-create_folder_if_needed.R
@@ -6,15 +6,13 @@ test_that("create_folder_if_needed() works - dir not exists", {
 
     path <- build_abs_path("R")
 
-    expect_silent(create_folder_if_needed(path))
-    x <- create_folder_if_needed(path)
+    x <- expect_silent(create_folder_if_needed(path))
     expect_null(x)
     expect_true(dir.exists(path))
 
     path <- build_abs_path("tests", "testthat")
 
-    expect_silent(create_folder_if_needed(path))
-    x <- create_folder_if_needed(path)
+    x <- expect_silent(create_folder_if_needed(path))
     expect_null(x)
     expect_true(dir.exists(path))
   })
@@ -27,16 +25,14 @@ test_that("create_folder_if_needed() works - dir exists", {
     path <- build_abs_path("man")
     dir.create(path, recursive = TRUE, showWarnings = FALSE)
 
-    expect_silent(create_folder_if_needed(path))
-    x <- create_folder_if_needed(path)
+    x <- expect_silent(create_folder_if_needed(path))
     expect_null(x)
     expect_true(dir.exists(path))
 
     path <- build_abs_path("man", "figures")
     dir.create(path, recursive = TRUE, showWarnings = FALSE)
 
-    expect_silent(create_folder_if_needed(path))
-    x <- create_folder_if_needed(path)
+    x <- expect_silent(create_folder_if_needed(path))
     expect_null(x)
     expect_true(dir.exists(path))
   })

--- a/tests/testthat/test-detect_r_function_names.R
+++ b/tests/testthat/test-detect_r_function_names.R
@@ -13,7 +13,9 @@ test_that("detect_r_function_names() works - No functions", {
 
     writeLines(content, asserts)
 
-    x <- expect_silent(detect_r_function_names())
+    expect_silent({
+      x <- detect_r_function_names()
+    })
     expect_true(inherits(x, "list"))
     expect_equal(length(x), 2L)
     expect_true("external" %in% names(x))
@@ -49,7 +51,9 @@ test_that("detect_r_function_names() works - No NAMESPACE", {
 
     writeLines(content, asserts)
 
-    x <- expect_silent(detect_r_function_names())
+    expect_silent({
+      x <- detect_r_function_names()
+    })
 
     expect_true(inherits(x, "list"))
     expect_equal(length(x), 2L)
@@ -91,7 +95,9 @@ test_that("detect_r_function_names() works - R functions + Empty NAMESPACE", {
 
     file.create(build_abs_path("NAMESPACE"))
 
-    x <- expect_silent(detect_r_function_names())
+    expect_silent({
+      x <- detect_r_function_names()
+    })
 
     expect_true(inherits(x, "list"))
     expect_equal(length(x), 2L)
@@ -140,7 +146,9 @@ test_that("detect_r_function_names() works - R functions + NAMESPACE", {
 
     writeLines(content, namespace)
 
-    x <- expect_silent(detect_r_function_names())
+    expect_silent({
+      x <- detect_r_function_names()
+    })
 
     expect_true(inherits(x, "list"))
     expect_equal(length(x), 2L)

--- a/tests/testthat/test-detect_r_function_names.R
+++ b/tests/testthat/test-detect_r_function_names.R
@@ -13,7 +13,8 @@ test_that("detect_r_function_names() works - No functions", {
 
     writeLines(content, asserts)
 
-    expect_silent(x <- detect_r_function_names())
+    x <- detect_r_function_names()
+    expect_silent(detect_r_function_names())
     expect_true(inherits(x, "list"))
     expect_equal(length(x), 2L)
     expect_true("external" %in% names(x))
@@ -49,7 +50,8 @@ test_that("detect_r_function_names() works - No NAMESPACE", {
 
     writeLines(content, asserts)
 
-    expect_silent(x <- detect_r_function_names())
+    x <- detect_r_function_names()
+    expect_silent(detect_r_function_names())
 
     expect_true(inherits(x, "list"))
     expect_equal(length(x), 2L)
@@ -91,7 +93,8 @@ test_that("detect_r_function_names() works - R functions + Empty NAMESPACE", {
 
     file.create(build_abs_path("NAMESPACE"))
 
-    expect_silent(x <- detect_r_function_names())
+    x <- detect_r_function_names()
+    expect_silent(detect_r_function_names())
 
     expect_true(inherits(x, "list"))
     expect_equal(length(x), 2L)
@@ -140,7 +143,8 @@ test_that("detect_r_function_names() works - R functions + NAMESPACE", {
 
     writeLines(content, namespace)
 
-    expect_silent(x <- detect_r_function_names())
+    x <- detect_r_function_names()
+    expect_silent(detect_r_function_names())
 
     expect_true(inherits(x, "list"))
     expect_equal(length(x), 2L)

--- a/tests/testthat/test-detect_r_function_names.R
+++ b/tests/testthat/test-detect_r_function_names.R
@@ -13,8 +13,7 @@ test_that("detect_r_function_names() works - No functions", {
 
     writeLines(content, asserts)
 
-    x <- detect_r_function_names()
-    expect_silent(detect_r_function_names())
+    x <- expect_silent(detect_r_function_names())
     expect_true(inherits(x, "list"))
     expect_equal(length(x), 2L)
     expect_true("external" %in% names(x))
@@ -50,8 +49,7 @@ test_that("detect_r_function_names() works - No NAMESPACE", {
 
     writeLines(content, asserts)
 
-    x <- detect_r_function_names()
-    expect_silent(detect_r_function_names())
+    x <- expect_silent(detect_r_function_names())
 
     expect_true(inherits(x, "list"))
     expect_equal(length(x), 2L)
@@ -93,8 +91,7 @@ test_that("detect_r_function_names() works - R functions + Empty NAMESPACE", {
 
     file.create(build_abs_path("NAMESPACE"))
 
-    x <- detect_r_function_names()
-    expect_silent(detect_r_function_names())
+    x <- expect_silent(detect_r_function_names())
 
     expect_true(inherits(x, "list"))
     expect_equal(length(x), 2L)
@@ -143,8 +140,7 @@ test_that("detect_r_function_names() works - R functions + NAMESPACE", {
 
     writeLines(content, namespace)
 
-    x <- detect_r_function_names()
-    expect_silent(detect_r_function_names())
+    x <- expect_silent(detect_r_function_names())
 
     expect_true(inherits(x, "list"))
     expect_equal(length(x), 2L)

--- a/tests/testthat/test-extract_exported_r_function_names.R
+++ b/tests/testthat/test-extract_exported_r_function_names.R
@@ -57,7 +57,8 @@ test_that("extract_exported_r_function_names() works - With export()", {
 
     writeLines(content, namespace)
 
-    expect_silent(x <- extract_exported_r_function_names())
+    x <- extract_exported_r_function_names()
+    expect_silent(extract_exported_r_function_names())
     expect_true(inherits(x, "character"))
     expect_equal(length(x), 1L)
     expect_equal(x[1], "try_read")

--- a/tests/testthat/test-extract_exported_r_function_names.R
+++ b/tests/testthat/test-extract_exported_r_function_names.R
@@ -57,7 +57,9 @@ test_that("extract_exported_r_function_names() works - With export()", {
 
     writeLines(content, namespace)
 
-    x <- expect_silent(extract_exported_r_function_names())
+    expect_silent({
+      x <- extract_exported_r_function_names()
+    })
     expect_true(inherits(x, "character"))
     expect_equal(length(x), 1L)
     expect_equal(x[1], "try_read")

--- a/tests/testthat/test-extract_exported_r_function_names.R
+++ b/tests/testthat/test-extract_exported_r_function_names.R
@@ -57,8 +57,7 @@ test_that("extract_exported_r_function_names() works - With export()", {
 
     writeLines(content, namespace)
 
-    x <- extract_exported_r_function_names()
-    expect_silent(extract_exported_r_function_names())
+    x <- expect_silent(extract_exported_r_function_names())
     expect_true(inherits(x, "character"))
     expect_equal(length(x), 1L)
     expect_equal(x[1], "try_read")

--- a/tests/testthat/test-extract_r_function_names.R
+++ b/tests/testthat/test-extract_r_function_names.R
@@ -36,7 +36,9 @@ test_that("read_r_files() works", {
     path <- get_r_file_paths()
     funs <- read_r_files(path)
 
-    x <- expect_silent(extract_r_function_names(funs))
+    expect_silent({
+      x <- extract_r_function_names(funs)
+    })
 
     expect_true(inherits(x, "character"))
     expect_equal(length(x), 3L)

--- a/tests/testthat/test-extract_r_function_names.R
+++ b/tests/testthat/test-extract_r_function_names.R
@@ -36,8 +36,7 @@ test_that("read_r_files() works", {
     path <- get_r_file_paths()
     funs <- read_r_files(path)
 
-    x <- extract_r_function_names(funs)
-    expect_silent(extract_r_function_names(funs))
+    x <- expect_silent(extract_r_function_names(funs))
 
     expect_true(inherits(x, "character"))
     expect_equal(length(x), 3L)

--- a/tests/testthat/test-extract_r_function_names.R
+++ b/tests/testthat/test-extract_r_function_names.R
@@ -36,7 +36,8 @@ test_that("read_r_files() works", {
     path <- get_r_file_paths()
     funs <- read_r_files(path)
 
-    expect_silent(x <- extract_r_function_names(funs))
+    x <- extract_r_function_names(funs)
+    expect_silent(extract_r_function_names(funs))
 
     expect_true(inherits(x, "character"))
     expect_equal(length(x), 3L)

--- a/tests/testthat/test-get_available_gh_actions.R
+++ b/tests/testthat/test-get_available_gh_actions.R
@@ -5,7 +5,7 @@ test_that("get_available_gh_actions() works", {
     templates <- get_available_gh_actions()
   })
 
-  expect_true(all(!grepl("\\.ya?ml$", templates)))
+  expect_true(!any(grepl("\\.ya?ml$", templates)))
   expect_true(length(templates) > 0)
   expect_true("test-coverage" %in% templates)
   expect_false("dependabot" %in% templates)

--- a/tests/testthat/test-get_available_issue_templates.R
+++ b/tests/testthat/test-get_available_issue_templates.R
@@ -5,7 +5,7 @@ test_that("get_available_issue_templates() works", {
     templates <- get_available_issue_templates()
   })
 
-  expect_true(all(!grepl("\\.md$", templates)))
+  expect_true(!any(grepl("\\.md$", templates)))
   expect_true(length(templates) > 0)
   expect_true("bug_report" %in% templates)
 })

--- a/tests/testthat/test-get_license_meta.R
+++ b/tests/testthat/test-get_license_meta.R
@@ -15,5 +15,6 @@ test_that("get_license_meta() works", {
 
 
 test_that("get_license_meta() NULL", {
-  expect_null(res <- get_license_meta(NULL))
+  res <- get_license_meta(NULL)
+  expect_null(res)
 })

--- a/tests/testthat/test-get_project_license_name.R
+++ b/tests/testthat/test-get_project_license_name.R
@@ -44,6 +44,7 @@ test_that("get_project_license_name() works - No License", {
   with_local_project({
     initialize_project(quiet = TRUE)
 
-    expect_null(res <- get_project_license_name())
+    res <- get_project_license_name()
+    expect_null(res)
   })
 })

--- a/tests/testthat/test-get_project_license_url.R
+++ b/tests/testthat/test-get_project_license_url.R
@@ -44,6 +44,7 @@ test_that("get_project_license_url() works - No License", {
   with_local_project({
     initialize_project(quiet = TRUE)
 
-    expect_null(res <- get_project_license_url())
+    res <- get_project_license_url()
+    expect_null(res)
   })
 })

--- a/tests/testthat/test-get_r_file_paths.R
+++ b/tests/testthat/test-get_r_file_paths.R
@@ -6,7 +6,9 @@ test_that("get_r_file_paths() works - empty R/", {
 
     dir.create(build_abs_path("R"))
 
-    x <- expect_silent(get_r_file_paths())
+    expect_silent({
+      x <- get_r_file_paths()
+    })
     expect_equal(length(x), 0L)
   })
 })
@@ -20,7 +22,9 @@ test_that("get_r_file_paths() works - no .R file in R/", {
     asserts <- build_abs_path("R", "asserts.Rmd")
     file.create(asserts)
 
-    x <- expect_silent(get_r_file_paths())
+    expect_silent({
+      x <- get_r_file_paths()
+    })
     expect_equal(length(x), 0L)
   })
 })
@@ -34,7 +38,9 @@ test_that("get_r_file_paths() works - not empty R/", {
     asserts <- build_abs_path("R", "asserts.R")
     file.create(asserts)
 
-    x <- expect_silent(get_r_file_paths())
+    expect_silent({
+      x <- get_r_file_paths()
+    })
     expect_true(inherits(x, "character"))
     expect_equal(length(x), 1L)
     expect_equal(x[1], asserts)
@@ -42,7 +48,9 @@ test_that("get_r_file_paths() works - not empty R/", {
     helpers <- build_abs_path("R", "helpers.R")
     file.create(helpers)
 
-    x <- expect_silent(get_r_file_paths())
+    expect_silent({
+      x <- get_r_file_paths()
+    })
     expect_true(inherits(x, "character"))
     expect_equal(length(x), 2L)
     expect_equal(x[1], asserts)

--- a/tests/testthat/test-get_r_file_paths.R
+++ b/tests/testthat/test-get_r_file_paths.R
@@ -6,8 +6,7 @@ test_that("get_r_file_paths() works - empty R/", {
 
     dir.create(build_abs_path("R"))
 
-    x <- get_r_file_paths()
-    expect_silent(get_r_file_paths())
+    x <- expect_silent(get_r_file_paths())
     expect_equal(length(x), 0L)
   })
 })
@@ -21,8 +20,7 @@ test_that("get_r_file_paths() works - no .R file in R/", {
     asserts <- build_abs_path("R", "asserts.Rmd")
     file.create(asserts)
 
-    x <- get_r_file_paths()
-    expect_silent(get_r_file_paths())
+    x <- expect_silent(get_r_file_paths())
     expect_equal(length(x), 0L)
   })
 })
@@ -36,8 +34,7 @@ test_that("get_r_file_paths() works - not empty R/", {
     asserts <- build_abs_path("R", "asserts.R")
     file.create(asserts)
 
-    x <- get_r_file_paths()
-    expect_silent(get_r_file_paths())
+    x <- expect_silent(get_r_file_paths())
     expect_true(inherits(x, "character"))
     expect_equal(length(x), 1L)
     expect_equal(x[1], asserts)
@@ -45,8 +42,7 @@ test_that("get_r_file_paths() works - not empty R/", {
     helpers <- build_abs_path("R", "helpers.R")
     file.create(helpers)
 
-    x <- get_r_file_paths()
-    expect_silent(get_r_file_paths())
+    x <- expect_silent(get_r_file_paths())
     expect_true(inherits(x, "character"))
     expect_equal(length(x), 2L)
     expect_equal(x[1], asserts)

--- a/tests/testthat/test-get_r_file_paths.R
+++ b/tests/testthat/test-get_r_file_paths.R
@@ -6,7 +6,8 @@ test_that("get_r_file_paths() works - empty R/", {
 
     dir.create(build_abs_path("R"))
 
-    expect_silent(x <- get_r_file_paths())
+    x <- get_r_file_paths()
+    expect_silent(get_r_file_paths())
     expect_equal(length(x), 0L)
   })
 })
@@ -20,7 +21,8 @@ test_that("get_r_file_paths() works - no .R file in R/", {
     asserts <- build_abs_path("R", "asserts.Rmd")
     file.create(asserts)
 
-    expect_silent(x <- get_r_file_paths())
+    x <- get_r_file_paths()
+    expect_silent(get_r_file_paths())
     expect_equal(length(x), 0L)
   })
 })
@@ -34,7 +36,8 @@ test_that("get_r_file_paths() works - not empty R/", {
     asserts <- build_abs_path("R", "asserts.R")
     file.create(asserts)
 
-    expect_silent(x <- get_r_file_paths())
+    x <- get_r_file_paths()
+    expect_silent(get_r_file_paths())
     expect_true(inherits(x, "character"))
     expect_equal(length(x), 1L)
     expect_equal(x[1], asserts)
@@ -42,7 +45,8 @@ test_that("get_r_file_paths() works - not empty R/", {
     helpers <- build_abs_path("R", "helpers.R")
     file.create(helpers)
 
-    expect_silent(x <- get_r_file_paths())
+    x <- get_r_file_paths()
+    expect_silent(get_r_file_paths())
     expect_true(inherits(x, "character"))
     expect_equal(length(x), 2L)
     expect_equal(x[1], asserts)

--- a/tests/testthat/test-populate_template.R
+++ b/tests/testthat/test-populate_template.R
@@ -11,8 +11,7 @@ test_that("populate_template() works - no metadata", {
 
     meta <- list()
 
-    expect_silent(populate_template(path, meta))
-    x <- populate_template(path, meta)
+    x <- expect_silent(populate_template(path, meta))
     expect_null(x)
 
     output <- readLines(path)
@@ -33,8 +32,7 @@ test_that("populate_template() works - unused metadata", {
 
     meta <- list(orcid = "0000-0000-0000-0000", github_user = "jdoe")
 
-    expect_silent(populate_template(path, meta))
-    x <- populate_template(path, meta)
+    x <- expect_silent(populate_template(path, meta))
     expect_null(x)
 
     output <- readLines(path)
@@ -55,8 +53,7 @@ test_that("populate_template() works - one used metadata", {
 
     meta <- list(given = "John", github_user = "jdoe")
 
-    expect_silent(populate_template(path, meta))
-    x <- populate_template(path, meta)
+    x <- expect_silent(populate_template(path, meta))
     expect_null(x)
 
     output <- readLines(path)
@@ -77,8 +74,7 @@ test_that("populate_template() works - one used metadata & one is NULL", {
 
     meta <- list(given = "John", family = NULL, github_user = "jdoe")
 
-    expect_silent(populate_template(path, meta))
-    x <- populate_template(path, meta)
+    x <- expect_silent(populate_template(path, meta))
     expect_null(x)
 
     output <- readLines(path)
@@ -104,8 +100,7 @@ test_that("populate_template() works - many used metadata", {
       github_user = "jdoe"
     )
 
-    expect_silent(populate_template(path, meta))
-    x <- populate_template(path, meta)
+    x <- expect_silent(populate_template(path, meta))
     expect_null(x)
 
     output <- readLines(path)

--- a/tests/testthat/test-populate_template.R
+++ b/tests/testthat/test-populate_template.R
@@ -12,7 +12,8 @@ test_that("populate_template() works - no metadata", {
     meta <- list()
 
     expect_silent(populate_template(path, meta))
-    expect_null(x <- populate_template(path, meta))
+    x <- populate_template(path, meta)
+    expect_null(x)
 
     output <- readLines(path)
 
@@ -33,7 +34,8 @@ test_that("populate_template() works - unused metadata", {
     meta <- list(orcid = "0000-0000-0000-0000", github_user = "jdoe")
 
     expect_silent(populate_template(path, meta))
-    expect_null(x <- populate_template(path, meta))
+    x <- populate_template(path, meta)
+    expect_null(x)
 
     output <- readLines(path)
 
@@ -54,7 +56,8 @@ test_that("populate_template() works - one used metadata", {
     meta <- list(given = "John", github_user = "jdoe")
 
     expect_silent(populate_template(path, meta))
-    expect_null(x <- populate_template(path, meta))
+    x <- populate_template(path, meta)
+    expect_null(x)
 
     output <- readLines(path)
 
@@ -75,7 +78,8 @@ test_that("populate_template() works - one used metadata & one is NULL", {
     meta <- list(given = "John", family = NULL, github_user = "jdoe")
 
     expect_silent(populate_template(path, meta))
-    expect_null(x <- populate_template(path, meta))
+    x <- populate_template(path, meta)
+    expect_null(x)
 
     output <- readLines(path)
 
@@ -101,7 +105,8 @@ test_that("populate_template() works - many used metadata", {
     )
 
     expect_silent(populate_template(path, meta))
-    expect_null(x <- populate_template(path, meta))
+    x <- populate_template(path, meta)
+    expect_null(x)
 
     output <- readLines(path)
 

--- a/tests/testthat/test-populate_template.R
+++ b/tests/testthat/test-populate_template.R
@@ -11,7 +11,9 @@ test_that("populate_template() works - no metadata", {
 
     meta <- list()
 
-    x <- expect_silent(populate_template(path, meta))
+    expect_silent({
+      x <- populate_template(path, meta)
+    })
     expect_null(x)
 
     output <- readLines(path)
@@ -32,7 +34,9 @@ test_that("populate_template() works - unused metadata", {
 
     meta <- list(orcid = "0000-0000-0000-0000", github_user = "jdoe")
 
-    x <- expect_silent(populate_template(path, meta))
+    expect_silent({
+      x <- populate_template(path, meta)
+    })
     expect_null(x)
 
     output <- readLines(path)
@@ -53,7 +57,9 @@ test_that("populate_template() works - one used metadata", {
 
     meta <- list(given = "John", github_user = "jdoe")
 
-    x <- expect_silent(populate_template(path, meta))
+    expect_silent({
+      x <- populate_template(path, meta)
+    })
     expect_null(x)
 
     output <- readLines(path)
@@ -74,7 +80,9 @@ test_that("populate_template() works - one used metadata & one is NULL", {
 
     meta <- list(given = "John", family = NULL, github_user = "jdoe")
 
-    x <- expect_silent(populate_template(path, meta))
+    expect_silent({
+      x <- populate_template(path, meta)
+    })
     expect_null(x)
 
     output <- readLines(path)
@@ -100,7 +108,9 @@ test_that("populate_template() works - many used metadata", {
       github_user = "jdoe"
     )
 
-    x <- expect_silent(populate_template(path, meta))
+    expect_silent({
+      x <- populate_template(path, meta)
+    })
     expect_null(x)
 
     output <- readLines(path)

--- a/tests/testthat/test-read_r_files.R
+++ b/tests/testthat/test-read_r_files.R
@@ -11,8 +11,7 @@ test_that("read_r_files() works - empty R files", {
 
     path <- get_r_file_paths()
 
-    x <- read_r_files(path)
-    expect_silent(read_r_files(path))
+    x <- expect_silent(read_r_files(path))
     expect_true(inherits(x, "list"))
     expect_equal(length(x), length(path))
     expect_equal(length(x[[1]]), 0L)
@@ -22,8 +21,7 @@ test_that("read_r_files() works - empty R files", {
 
     path <- get_r_file_paths()
 
-    x <- read_r_files(path)
-    expect_silent(read_r_files(path))
+    x <- expect_silent(read_r_files(path))
     expect_true(inherits(x, "list"))
     expect_equal(length(x), length(path))
     expect_equal(length(x[[1]]), 0L)
@@ -51,8 +49,7 @@ test_that("read_r_files() works - R files w/ content", {
 
     path <- get_r_file_paths()
 
-    x <- read_r_files(path)
-    expect_silent(read_r_files(path))
+    x <- expect_silent(read_r_files(path))
     expect_true(inherits(x, "list"))
     expect_equal(length(x), length(path))
     expect_equal(length(x[[1]]), 6L)
@@ -74,8 +71,7 @@ test_that("read_r_files() works - R files w/ content", {
 
     path <- get_r_file_paths()
 
-    x <- read_r_files(path)
-    expect_silent(read_r_files(path))
+    x <- expect_silent(read_r_files(path))
     expect_true(inherits(x, "list"))
 
     expect_equal(length(x), length(path))
@@ -93,8 +89,7 @@ test_that("read_r_files() works - R files w/ content", {
 
     path <- get_r_file_paths()
 
-    x <- read_r_files(path)
-    expect_silent(read_r_files(path))
+    x <- expect_silent(read_r_files(path))
     expect_true(inherits(x, "list"))
 
     expect_equal(length(x), length(path))

--- a/tests/testthat/test-read_r_files.R
+++ b/tests/testthat/test-read_r_files.R
@@ -11,7 +11,8 @@ test_that("read_r_files() works - empty R files", {
 
     path <- get_r_file_paths()
 
-    expect_silent(x <- read_r_files(path))
+    x <- read_r_files(path)
+    expect_silent(read_r_files(path))
     expect_true(inherits(x, "list"))
     expect_equal(length(x), length(path))
     expect_equal(length(x[[1]]), 0L)
@@ -21,7 +22,8 @@ test_that("read_r_files() works - empty R files", {
 
     path <- get_r_file_paths()
 
-    expect_silent(x <- read_r_files(path))
+    x <- read_r_files(path)
+    expect_silent(read_r_files(path))
     expect_true(inherits(x, "list"))
     expect_equal(length(x), length(path))
     expect_equal(length(x[[1]]), 0L)
@@ -49,7 +51,8 @@ test_that("read_r_files() works - R files w/ content", {
 
     path <- get_r_file_paths()
 
-    expect_silent(x <- read_r_files(path))
+    x <- read_r_files(path)
+    expect_silent(read_r_files(path))
     expect_true(inherits(x, "list"))
     expect_equal(length(x), length(path))
     expect_equal(length(x[[1]]), 6L)
@@ -71,7 +74,8 @@ test_that("read_r_files() works - R files w/ content", {
 
     path <- get_r_file_paths()
 
-    expect_silent(x <- read_r_files(path))
+    x <- read_r_files(path)
+    expect_silent(read_r_files(path))
     expect_true(inherits(x, "list"))
 
     expect_equal(length(x), length(path))
@@ -89,7 +93,8 @@ test_that("read_r_files() works - R files w/ content", {
 
     path <- get_r_file_paths()
 
-    expect_silent(x <- read_r_files(path))
+    x <- read_r_files(path)
+    expect_silent(read_r_files(path))
     expect_true(inherits(x, "list"))
 
     expect_equal(length(x), length(path))

--- a/tests/testthat/test-read_r_files.R
+++ b/tests/testthat/test-read_r_files.R
@@ -11,7 +11,9 @@ test_that("read_r_files() works - empty R files", {
 
     path <- get_r_file_paths()
 
-    x <- expect_silent(read_r_files(path))
+    expect_silent({
+      x <- read_r_files(path)
+    })
     expect_true(inherits(x, "list"))
     expect_equal(length(x), length(path))
     expect_equal(length(x[[1]]), 0L)
@@ -21,7 +23,9 @@ test_that("read_r_files() works - empty R files", {
 
     path <- get_r_file_paths()
 
-    x <- expect_silent(read_r_files(path))
+    expect_silent({
+      x <- read_r_files(path)
+    })
     expect_true(inherits(x, "list"))
     expect_equal(length(x), length(path))
     expect_equal(length(x[[1]]), 0L)
@@ -49,7 +53,9 @@ test_that("read_r_files() works - R files w/ content", {
 
     path <- get_r_file_paths()
 
-    x <- expect_silent(read_r_files(path))
+    expect_silent({
+      x <- read_r_files(path)
+    })
     expect_true(inherits(x, "list"))
     expect_equal(length(x), length(path))
     expect_equal(length(x[[1]]), 6L)
@@ -71,7 +77,9 @@ test_that("read_r_files() works - R files w/ content", {
 
     path <- get_r_file_paths()
 
-    x <- expect_silent(read_r_files(path))
+    expect_silent({
+      x <- read_r_files(path)
+    })
     expect_true(inherits(x, "list"))
 
     expect_equal(length(x), length(path))
@@ -89,7 +97,9 @@ test_that("read_r_files() works - R files w/ content", {
 
     path <- get_r_file_paths()
 
-    x <- expect_silent(read_r_files(path))
+    expect_silent({
+      x <- read_r_files(path)
+    })
     expect_true(inherits(x, "list"))
 
     expect_equal(length(x), length(path))

--- a/tests/testthat/test-stop_if_file_exists.R
+++ b/tests/testthat/test-stop_if_file_exists.R
@@ -25,9 +25,8 @@ test_that("stop_if_file_exists() works - overwrite is TRUE", {
       stop_if_file_exists("README", overwrite = TRUE)
     )
 
-    expect_null(
-      x <- stop_if_file_exists("README", overwrite = TRUE)
-    )
+    x <- stop_if_file_exists("README", overwrite = TRUE)
+    expect_null(x)
 
     invisible(file.create("README"))
 
@@ -35,9 +34,8 @@ test_that("stop_if_file_exists() works - overwrite is TRUE", {
       stop_if_file_exists("README", overwrite = TRUE)
     )
 
-    expect_null(
-      x <- stop_if_file_exists("README", overwrite = TRUE)
-    )
+    x <- stop_if_file_exists("README", overwrite = TRUE)
+    expect_null(x)
   })
 })
 
@@ -49,8 +47,7 @@ test_that("stop_if_file_exists() works - file not exists", {
       stop_if_file_exists("README", overwrite = FALSE)
     )
 
-    expect_null(
-      x <- stop_if_file_exists("README", overwrite = FALSE)
-    )
+    x <- stop_if_file_exists("README", overwrite = FALSE)
+    expect_null(x)
   })
 })

--- a/tests/testthat/test-stop_if_invalid_credentials.R
+++ b/tests/testthat/test-stop_if_invalid_credentials.R
@@ -209,73 +209,59 @@ test_that("stop_if_invalid_credentials() errors", {
 test_that("stop_if_invalid_credentials() works", {
   meta <- list()
 
-  expect_silent(stop_if_invalid_credentials(meta))
-  x <- stop_if_invalid_credentials(meta)
+  x <- expect_silent(stop_if_invalid_credentials(meta))
   expect_null(x)
 
   meta <- list(given = "John")
-  expect_silent(stop_if_invalid_credentials(meta))
-  x <- stop_if_invalid_credentials(meta)
+  x <- expect_silent(stop_if_invalid_credentials(meta))
   expect_null(x)
 
   meta <- list(family = "Doe")
-  expect_silent(stop_if_invalid_credentials(meta))
-  x <- stop_if_invalid_credentials(meta)
+  x <- expect_silent(stop_if_invalid_credentials(meta))
   expect_null(x)
 
   meta <- list(given = "John", family = "Doe")
-  expect_silent(stop_if_invalid_credentials(meta))
-  x <- stop_if_invalid_credentials(meta)
+  x <- expect_silent(stop_if_invalid_credentials(meta))
   expect_null(x)
 
   meta <- list(email = "john.doe@mail.com")
-  expect_silent(stop_if_invalid_credentials(meta))
-  x <- stop_if_invalid_credentials(meta)
+  x <- expect_silent(stop_if_invalid_credentials(meta))
   expect_null(x)
 
   meta <- list(email = "john.doe@mail.com", family = "Doe")
-  expect_silent(stop_if_invalid_credentials(meta))
-  x <- stop_if_invalid_credentials(meta)
+  x <- expect_silent(stop_if_invalid_credentials(meta))
   expect_null(x)
 
   meta <- list(orcid = "0000-0000-0000-0000")
-  expect_silent(stop_if_invalid_credentials(meta))
-  x <- stop_if_invalid_credentials(meta)
+  x <- expect_silent(stop_if_invalid_credentials(meta))
   expect_null(x)
 
   meta <- list(given = "John", orcid = "0000-0000-0000-0000")
-  expect_silent(stop_if_invalid_credentials(meta))
-  x <- stop_if_invalid_credentials(meta)
+  x <- expect_silent(stop_if_invalid_credentials(meta))
   expect_null(x)
 
   meta <- list(github_user = "jdoe")
-  expect_silent(stop_if_invalid_credentials(meta))
-  x <- stop_if_invalid_credentials(meta)
+  x <- expect_silent(stop_if_invalid_credentials(meta))
   expect_null(x)
 
   meta <- list(github_user = "jdoe", family = "Doe")
-  expect_silent(stop_if_invalid_credentials(meta))
-  x <- stop_if_invalid_credentials(meta)
+  x <- expect_silent(stop_if_invalid_credentials(meta))
   expect_null(x)
 
   meta <- list(protocol = "https")
-  expect_silent(stop_if_invalid_credentials(meta))
-  x <- stop_if_invalid_credentials(meta)
+  x <- expect_silent(stop_if_invalid_credentials(meta))
   expect_null(x)
 
   meta <- list(protocol = "https", family = "Doe")
-  expect_silent(stop_if_invalid_credentials(meta))
-  x <- stop_if_invalid_credentials(meta)
+  x <- expect_silent(stop_if_invalid_credentials(meta))
   expect_null(x)
 
   meta <- list(protocol = "ssh")
-  expect_silent(stop_if_invalid_credentials(meta))
-  x <- stop_if_invalid_credentials(meta)
+  x <- expect_silent(stop_if_invalid_credentials(meta))
   expect_null(x)
 
   meta <- list(protocol = "ssh", family = "Doe")
-  expect_silent(stop_if_invalid_credentials(meta))
-  x <- stop_if_invalid_credentials(meta)
+  x <- expect_silent(stop_if_invalid_credentials(meta))
   expect_null(x)
 
   meta <- list(
@@ -287,7 +273,6 @@ test_that("stop_if_invalid_credentials() works", {
     protocol = "ssh"
   )
 
-  expect_silent(stop_if_invalid_credentials(meta))
-  x <- stop_if_invalid_credentials(meta)
+  x <- expect_silent(stop_if_invalid_credentials(meta))
   expect_null(x)
 })

--- a/tests/testthat/test-stop_if_invalid_credentials.R
+++ b/tests/testthat/test-stop_if_invalid_credentials.R
@@ -209,59 +209,87 @@ test_that("stop_if_invalid_credentials() errors", {
 test_that("stop_if_invalid_credentials() works", {
   meta <- list()
 
-  x <- expect_silent(stop_if_invalid_credentials(meta))
+  expect_silent({
+    x <- stop_if_invalid_credentials(meta)
+  })
   expect_null(x)
 
   meta <- list(given = "John")
-  x <- expect_silent(stop_if_invalid_credentials(meta))
+  expect_silent({
+    x <- stop_if_invalid_credentials(meta)
+  })
   expect_null(x)
 
   meta <- list(family = "Doe")
-  x <- expect_silent(stop_if_invalid_credentials(meta))
+  expect_silent({
+    x <- stop_if_invalid_credentials(meta)
+  })
   expect_null(x)
 
   meta <- list(given = "John", family = "Doe")
-  x <- expect_silent(stop_if_invalid_credentials(meta))
+  expect_silent({
+    x <- stop_if_invalid_credentials(meta)
+  })
   expect_null(x)
 
   meta <- list(email = "john.doe@mail.com")
-  x <- expect_silent(stop_if_invalid_credentials(meta))
+  expect_silent({
+    x <- stop_if_invalid_credentials(meta)
+  })
   expect_null(x)
 
   meta <- list(email = "john.doe@mail.com", family = "Doe")
-  x <- expect_silent(stop_if_invalid_credentials(meta))
+  expect_silent({
+    x <- stop_if_invalid_credentials(meta)
+  })
   expect_null(x)
 
   meta <- list(orcid = "0000-0000-0000-0000")
-  x <- expect_silent(stop_if_invalid_credentials(meta))
+  expect_silent({
+    x <- stop_if_invalid_credentials(meta)
+  })
   expect_null(x)
 
   meta <- list(given = "John", orcid = "0000-0000-0000-0000")
-  x <- expect_silent(stop_if_invalid_credentials(meta))
+  expect_silent({
+    x <- stop_if_invalid_credentials(meta)
+  })
   expect_null(x)
 
   meta <- list(github_user = "jdoe")
-  x <- expect_silent(stop_if_invalid_credentials(meta))
+  expect_silent({
+    x <- stop_if_invalid_credentials(meta)
+  })
   expect_null(x)
 
   meta <- list(github_user = "jdoe", family = "Doe")
-  x <- expect_silent(stop_if_invalid_credentials(meta))
+  expect_silent({
+    x <- stop_if_invalid_credentials(meta)
+  })
   expect_null(x)
 
   meta <- list(protocol = "https")
-  x <- expect_silent(stop_if_invalid_credentials(meta))
+  expect_silent({
+    x <- stop_if_invalid_credentials(meta)
+  })
   expect_null(x)
 
   meta <- list(protocol = "https", family = "Doe")
-  x <- expect_silent(stop_if_invalid_credentials(meta))
+  expect_silent({
+    x <- stop_if_invalid_credentials(meta)
+  })
   expect_null(x)
 
   meta <- list(protocol = "ssh")
-  x <- expect_silent(stop_if_invalid_credentials(meta))
+  expect_silent({
+    x <- stop_if_invalid_credentials(meta)
+  })
   expect_null(x)
 
   meta <- list(protocol = "ssh", family = "Doe")
-  x <- expect_silent(stop_if_invalid_credentials(meta))
+  expect_silent({
+    x <- stop_if_invalid_credentials(meta)
+  })
   expect_null(x)
 
   meta <- list(
@@ -273,6 +301,8 @@ test_that("stop_if_invalid_credentials() works", {
     protocol = "ssh"
   )
 
-  x <- expect_silent(stop_if_invalid_credentials(meta))
+  expect_silent({
+    x <- stop_if_invalid_credentials(meta)
+  })
   expect_null(x)
 })

--- a/tests/testthat/test-stop_if_invalid_credentials.R
+++ b/tests/testthat/test-stop_if_invalid_credentials.R
@@ -210,59 +210,73 @@ test_that("stop_if_invalid_credentials() works", {
   meta <- list()
 
   expect_silent(stop_if_invalid_credentials(meta))
-  expect_null(x <- stop_if_invalid_credentials(meta))
+  x <- stop_if_invalid_credentials(meta)
+  expect_null(x)
 
   meta <- list(given = "John")
   expect_silent(stop_if_invalid_credentials(meta))
-  expect_null(x <- stop_if_invalid_credentials(meta))
+  x <- stop_if_invalid_credentials(meta)
+  expect_null(x)
 
   meta <- list(family = "Doe")
   expect_silent(stop_if_invalid_credentials(meta))
-  expect_null(x <- stop_if_invalid_credentials(meta))
+  x <- stop_if_invalid_credentials(meta)
+  expect_null(x)
 
   meta <- list(given = "John", family = "Doe")
   expect_silent(stop_if_invalid_credentials(meta))
-  expect_null(x <- stop_if_invalid_credentials(meta))
+  x <- stop_if_invalid_credentials(meta)
+  expect_null(x)
 
   meta <- list(email = "john.doe@mail.com")
   expect_silent(stop_if_invalid_credentials(meta))
-  expect_null(x <- stop_if_invalid_credentials(meta))
+  x <- stop_if_invalid_credentials(meta)
+  expect_null(x)
 
   meta <- list(email = "john.doe@mail.com", family = "Doe")
   expect_silent(stop_if_invalid_credentials(meta))
-  expect_null(x <- stop_if_invalid_credentials(meta))
+  x <- stop_if_invalid_credentials(meta)
+  expect_null(x)
 
   meta <- list(orcid = "0000-0000-0000-0000")
   expect_silent(stop_if_invalid_credentials(meta))
-  expect_null(x <- stop_if_invalid_credentials(meta))
+  x <- stop_if_invalid_credentials(meta)
+  expect_null(x)
 
   meta <- list(given = "John", orcid = "0000-0000-0000-0000")
   expect_silent(stop_if_invalid_credentials(meta))
-  expect_null(x <- stop_if_invalid_credentials(meta))
+  x <- stop_if_invalid_credentials(meta)
+  expect_null(x)
 
   meta <- list(github_user = "jdoe")
   expect_silent(stop_if_invalid_credentials(meta))
-  expect_null(x <- stop_if_invalid_credentials(meta))
+  x <- stop_if_invalid_credentials(meta)
+  expect_null(x)
 
   meta <- list(github_user = "jdoe", family = "Doe")
   expect_silent(stop_if_invalid_credentials(meta))
-  expect_null(x <- stop_if_invalid_credentials(meta))
+  x <- stop_if_invalid_credentials(meta)
+  expect_null(x)
 
   meta <- list(protocol = "https")
   expect_silent(stop_if_invalid_credentials(meta))
-  expect_null(x <- stop_if_invalid_credentials(meta))
+  x <- stop_if_invalid_credentials(meta)
+  expect_null(x)
 
   meta <- list(protocol = "https", family = "Doe")
   expect_silent(stop_if_invalid_credentials(meta))
-  expect_null(x <- stop_if_invalid_credentials(meta))
+  x <- stop_if_invalid_credentials(meta)
+  expect_null(x)
 
   meta <- list(protocol = "ssh")
   expect_silent(stop_if_invalid_credentials(meta))
-  expect_null(x <- stop_if_invalid_credentials(meta))
+  x <- stop_if_invalid_credentials(meta)
+  expect_null(x)
 
   meta <- list(protocol = "ssh", family = "Doe")
   expect_silent(stop_if_invalid_credentials(meta))
-  expect_null(x <- stop_if_invalid_credentials(meta))
+  x <- stop_if_invalid_credentials(meta)
+  expect_null(x)
 
   meta <- list(
     given = "John",
@@ -274,5 +288,6 @@ test_that("stop_if_invalid_credentials() works", {
   )
 
   expect_silent(stop_if_invalid_credentials(meta))
-  expect_null(x <- stop_if_invalid_credentials(meta))
+  x <- stop_if_invalid_credentials(meta)
+  expect_null(x)
 })

--- a/tests/testthat/test-stop_if_invalid_git_protocol.R
+++ b/tests/testthat/test-stop_if_invalid_git_protocol.R
@@ -23,5 +23,6 @@ test_that("stop_if_invalid_git_protocol() errors", {
 test_that("stop_if_invalid_git_protocol() works", {
   expect_silent(stop_if_invalid_git_protocol(list(protocol = "https")))
   expect_silent(stop_if_invalid_git_protocol(list(protocol = "ssh")))
-  expect_null(x <- stop_if_invalid_git_protocol(list(protocol = "ssh")))
+  x <- stop_if_invalid_git_protocol(list(protocol = "ssh"))
+  expect_null(x)
 })


### PR DESCRIPTION
this PR  fixes #149 

Most fixes were applied by `jarl` (default rules)

``` bash
jarl check . --fix
```

## Summary (GH Copilot)

**Code simplification and consistency:**
* Replaces `x[!(x == "")]` with the simpler and more idiomatic `x[x != ""]` for removing empty strings in multiple R scripts, including `add_badge.R`, `add_renv.R`, `add_vignette.R`, `get_all_dependencies.R`, `get_minimal_r_version.R`, and utility functions in `utils-deps.R`. [[1]](diffhunk://#diff-889f6c95e11a176d82777fe2b0c8bb2b3fa8684c82a55584e087bb7a84b6897aL52-R52) [[2]](diffhunk://#diff-96979124e7fea21dad78618e7bdb51701f490f976ae6d11f77b744fc1cc774eeL70-R77) [[3]](diffhunk://#diff-61a7bf85b8b309e486a1932f2632eb9b966bdfbf835122ca1593ceb957f749a4L167-R174) [[4]](diffhunk://#diff-af2e5db1742325e30094b4c1d207c72ae5d5daedc13331566da39eaec7e68c1cL46-R46) [[5]](diffhunk://#diff-7b09f9716cb2bdcc5acda26d667e22062920546e4348e8b0778ee171b681eb97L41-R41) [[6]](diffhunk://#diff-b2bf1480ddfc7ec074b56492510b5c8e958b3a2511ee3cd0d52ef4436d39a171L667-R667) [[7]](diffhunk://#diff-b2bf1480ddfc7ec074b56492510b5c8e958b3a2511ee3cd0d52ef4436d39a171L687-R687) [[8]](diffhunk://#diff-b2bf1480ddfc7ec074b56492510b5c8e958b3a2511ee3cd0d52ef4436d39a171L706-R706)

**Test refactoring and clarity:**
* Refactors tests to separate assignment and assertion steps, e.g., splitting `expect_null(x <- foo())` into `x <- foo(); expect_null(x)`, and similarly for other assertions. This affects many test files, improving readability and debuggability. [[1]](diffhunk://#diff-bb35b0a8b3571a13330c97a4863ee29c205ca69461e903e14e5e15eae9586aa9L10-R18) [[2]](diffhunk://#diff-bb35b0a8b3571a13330c97a4863ee29c205ca69461e903e14e5e15eae9586aa9L29-R40) [[3]](diffhunk://#diff-07d3518e37cabb0ee83561fa9b2eeb6731db590eb2a76e0a83bc880b964cf673L16-R17) [[4]](diffhunk://#diff-07d3518e37cabb0ee83561fa9b2eeb6731db590eb2a76e0a83bc880b964cf673L52-R54) [[5]](diffhunk://#diff-07d3518e37cabb0ee83561fa9b2eeb6731db590eb2a76e0a83bc880b964cf673L94-R97) [[6]](diffhunk://#diff-07d3518e37cabb0ee83561fa9b2eeb6731db590eb2a76e0a83bc880b964cf673L143-R147) [[7]](diffhunk://#diff-76c0d447b31b0ffe0c9132b4e8c19d7f4c1f4026d418289b6b126de1c22ba494L60-R61) [[8]](diffhunk://#diff-e397f8f17721397d4c7539745189546dd2181263742ad0aea31ce58606cb3c7fL39-R40) [[9]](diffhunk://#diff-1780b2ab9e84e655cbb56f79f232f6800d2bc01f0ad70d2986879ae45b0611baL18-R19) [[10]](diffhunk://#diff-1e1defa97f76be91c239275db937d2c6c22d5f3f1f2efc6230a846ec80c6bde4L47-R48) [[11]](diffhunk://#diff-717f3e8122c007a126736dc2b75b63293439b9ca4b2f7066fd3a0651192ef437L47-R48) [[12]](diffhunk://#diff-205d8937abefe07f9a9d24b8c77471f5670c20c878645e7fabcf8cdb86efc886L9-R10) [[13]](diffhunk://#diff-205d8937abefe07f9a9d24b8c77471f5670c20c878645e7fabcf8cdb86efc886L23-R25) [[14]](diffhunk://#diff-205d8937abefe07f9a9d24b8c77471f5670c20c878645e7fabcf8cdb86efc886L37-R49) [[15]](diffhunk://#diff-9243b7e65b2df50e65266ec75e14827ffb0a8d317c28aac01ad08fdd98fe32f1L15-R16) [[16]](diffhunk://#diff-9243b7e65b2df50e65266ec75e14827ffb0a8d317c28aac01ad08fdd98fe32f1L36-R38) [[17]](diffhunk://#diff-9243b7e65b2df50e65266ec75e14827ffb0a8d317c28aac01ad08fdd98fe32f1L57-R60) [[18]](diffhunk://#diff-9243b7e65b2df50e65266ec75e14827ffb0a8d317c28aac01ad08fdd98fe32f1L78-R82) [[19]](diffhunk://#diff-9243b7e65b2df50e65266ec75e14827ffb0a8d317c28aac01ad08fdd98fe32f1L104-R109) [[20]](diffhunk://#diff-6e442461cb48314767cb68abb1e50999fca7d9a114404b0894c7826e2146e879L14-R15) [[21]](diffhunk://#diff-6e442461cb48314767cb68abb1e50999fca7d9a114404b0894c7826e2146e879L24-R26) [[22]](diffhunk://#diff-6e442461cb48314767cb68abb1e50999fca7d9a114404b0894c7826e2146e879L52-R55) [[23]](diffhunk://#diff-6e442461cb48314767cb68abb1e50999fca7d9a114404b0894c7826e2146e879L74-R78) [[24]](diffhunk://#diff-6e442461cb48314767cb68abb1e50999fca7d9a114404b0894c7826e2146e879L92-R97)

* Updates test logic to use `!any(grepl(...))` instead of `all(!grepl(...))` for improved clarity and intent in pattern matching assertions. [[1]](diffhunk://#diff-3d5627408d1fd455ef677715451a571d5c3c122f26b36865e36844e8e7709d09L8-R8) [[2]](diffhunk://#diff-79cb3cba1648dab56e239fb57768ee7e54f3689886ddc00bc5247de13c04ec4aL8-R8)

**Utility function improvements:**
* Improves argument validation in `resolve_project_meta` by using `anyNA()` instead of `any(is.na(...))` and by replacing `any(!(x %in% y))` with `!all(x %in% y)`, making the logic more idiomatic and robust.

These changes do not affect the core logic or output of the functions but improve code readability, maintainability, and test clarity.